### PR TITLE
Rank training labels descending and fix standardization

### DIFF
--- a/pipelines/etl_standardize.py
+++ b/pipelines/etl_standardize.py
@@ -33,15 +33,18 @@ def standardize(df: pd.DataFrame) -> pd.DataFrame:
     df = df.sort_values("_ingested_at").drop_duplicates(
         subset=["asin", "site", "dt"], keep="last"
     )
-    df["price_valid"] = df["price"].apply(lambda v: v is not None and v > 0)
-    df["bsr_valid"] = df["bsr"].apply(lambda v: v is not None and 0 < v < 5_000_000)
+    price_valid = df["price"].apply(lambda v: v is not None and v > 0)
+    bsr_valid = df["bsr"].apply(lambda v: v is not None and 0 < v < 5_000_000)
 
-    df.loc[~df["price_valid"], "price"] = None
-    df.loc[~df["bsr_valid"], "bsr"] = None
+    df["price_valid"] = price_valid.astype(object)
+    df["bsr_valid"] = bsr_valid.astype(object)
 
-    df["price"] = df["price"].astype(float)
+    df["price"] = df["price"].astype(float).astype(object)
+    df["bsr"] = df["bsr"].astype(float).astype(object)
     df["rating"] = df["rating"].astype(float)
-    df["dt"] = pd.to_datetime(df["dt"]).dt.date
+    df.loc[~price_valid, "price"] = None
+    df.loc[~bsr_valid, "bsr"] = None
+    df["dt"] = pd.to_datetime(df["dt"]).dt.normalize()
     return df
 
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from training.build_labels import _compute_rank_target
+
+
+def test_highest_future_sales_receives_largest_rank() -> None:
+    df = pd.DataFrame(
+        {
+            "asin": ["A", "A", "A", "B", "B"],
+            "future_sales": [10.0, 20.0, 5.0, 3.0, 7.0],
+        }
+    )
+
+    for asin, group in df.groupby("asin", sort=False):
+        ranked = _compute_rank_target(group)
+        top_row = ranked.loc[group["future_sales"].idxmax()]
+        assert top_row["y_rank"] == ranked["y_rank"].max(), asin

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,0 +1,7 @@
+"""Training utilities for label construction."""
+
+__all__ = [
+    "_compute_rank_target",
+]
+
+from .build_labels import _compute_rank_target

--- a/training/build_labels.py
+++ b/training/build_labels.py
@@ -1,0 +1,27 @@
+"""Helpers for constructing supervised learning targets."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def _compute_rank_target(group: pd.DataFrame) -> pd.DataFrame:
+    """Assign a percentile rank target based on future sales.
+
+    The input ``group`` is expected to contain a ``future_sales`` column. Rows
+    are ranked in descending order such that the highest ``future_sales`` value
+    receives the largest percentile. The resulting percentile is stored in the
+    ``y_rank`` column alongside the original data.
+    """
+
+    if "future_sales" not in group:
+        raise KeyError("future_sales column is required to compute rank target")
+
+    ranked = group.copy()
+    order = ranked["future_sales"].rank(method="min", ascending=False)
+    max_rank = order.max()
+    if pd.isna(max_rank) or max_rank == 0:
+        ranked["y_rank"] = pd.NA
+        return ranked
+
+    ranked["y_rank"] = (max_rank - order + 1) / max_rank
+    return ranked


### PR DESCRIPTION
## Summary
- compute label percentiles by ranking future sales in descending order and expose the helper in the training package
- add a unit test that confirms the highest future_sales entry in each group receives the top y_rank percentile
- update ETL standardization to preserve Python bool validation flags, keep invalid metrics as None, and normalise dates while keeping pandas-friendly dtypes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0d61617e4832db0fc1aabb79da2e3