### PR TITLE
Ensure numeric BSR handling and add regression coverage

### DIFF
--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -7,6 +7,7 @@ import pytest
 pd = pytest.importorskip("pandas")
 
 from pipelines.etl_standardize import run
+from training.build_labels import build_labels
 
 
 def test_standardize_handles_duplicates_and_flags():
@@ -42,6 +43,47 @@ def test_standardize_handles_duplicates_and_flags():
     result = run([raw])
     assert len(result) == 1
     row = result.iloc[0]
-    assert row["price_valid"] is True
-    assert row["bsr_valid"] is False
-    assert row["bsr"] is None
+    assert bool(row["price_valid"])
+    assert not row["bsr_valid"]
+    assert pd.isna(row["bsr"])
+
+
+def test_standardize_and_build_labels_handle_invalid_bsr():
+    raw = pd.DataFrame(
+        [
+            {
+                "asin": "A",
+                "site": "US",
+                "dt": "2024-01-01",
+                "price": 10,
+                "bsr": "not-a-number",
+                "rating": 4.5,
+                "reviews_count": 5,
+                "stock_est": 1,
+                "buybox_seller": "Seller1",
+                "_ingested_at": datetime(2024, 1, 1, 1),
+            },
+            {
+                "asin": "A",
+                "site": "US",
+                "dt": "2024-01-02",
+                "price": 12,
+                "bsr": 100,
+                "rating": 4.6,
+                "reviews_count": 6,
+                "stock_est": 2,
+                "buybox_seller": "Seller1",
+                "_ingested_at": datetime(2024, 1, 2, 1),
+            },
+        ]
+    )
+
+    standardized = run([raw])
+    assert list(standardized["bsr_valid"]) == [False, True]
+    labels = build_labels(standardized)
+
+    first_row = labels.iloc[0]
+    assert pd.isna(first_row["bsr"])
+    assert not first_row["bsr_valid"]
+    assert first_row["future_bsr"] == pytest.approx(100.0)
+    assert not first_row["bsr_improved"]

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -2,6 +2,8 @@
 
 __all__ = [
     "_compute_rank_target",
+    "_prepare_frame",
+    "build_labels",
 ]
 
-from .build_labels import _compute_rank_target
+from .build_labels import _compute_rank_target, _prepare_frame, build_labels

--- a/training/build_labels.py
+++ b/training/build_labels.py
@@ -4,6 +4,47 @@ from __future__ import annotations
 import pandas as pd
 
 
+def _prepare_frame(mart_df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize the mart frame prior to label construction."""
+
+    if mart_df.empty:
+        return mart_df.copy()
+
+    prepared = mart_df.copy()
+    if "dt" in prepared.columns:
+        prepared["dt"] = pd.to_datetime(prepared["dt"])
+    if "bsr" in prepared.columns:
+        prepared["bsr"] = pd.to_numeric(prepared["bsr"], errors="coerce")
+    sort_columns = [col for col in ["asin", "site", "dt"] if col in prepared.columns]
+    if sort_columns:
+        prepared = prepared.sort_values(sort_columns)  # type: ignore[assignment]
+    return prepared
+
+
+def build_labels(mart_df: pd.DataFrame, horizon_days: int = 1) -> pd.DataFrame:
+    """Create future looking labels for BSR performance."""
+
+    prepared = _prepare_frame(mart_df)
+    if prepared.empty:
+        prepared = prepared.copy()
+        prepared["future_bsr"] = pd.Series(dtype="float64")
+        prepared["bsr_improved"] = pd.Series(dtype="bool")
+        return prepared
+
+    horizon = max(int(horizon_days), 1)
+    prepared = prepared.copy()
+    group_keys = [col for col in ["asin", "site"] if col in prepared.columns]
+    if group_keys:
+        prepared["future_bsr"] = (
+            prepared.groupby(group_keys, sort=False)["bsr"].shift(-horizon)
+        )
+    else:
+        prepared["future_bsr"] = prepared["bsr"].shift(-horizon)
+    comparison = prepared["future_bsr"] < prepared["bsr"]
+    prepared["bsr_improved"] = comparison.fillna(False)
+    return prepared
+
+
 def _compute_rank_target(group: pd.DataFrame) -> pd.DataFrame:
     """Assign a percentile rank target based on future sales.
 


### PR DESCRIPTION
## Summary
- keep standardized price, bsr, and rating columns numeric while leaving validity flags boolean
- coerce BSR to numeric inside the label builder before computing future comparisons
- add regression coverage confirming invalid BSR values remain flagged yet safely processed

## Testing
- pytest tests/test_etl.py

------
https://chatgpt.com/codex/tasks/task_e_68e0e0551158832d98c0d1049bc5797e