### PR TITLE
Ensure standardized metrics remain numeric

### DIFF
--- a/pipelines/etl_standardize.py
+++ b/pipelines/etl_standardize.py
@@ -5,6 +5,7 @@ import argparse
 from datetime import date
 from typing import Iterable
 
+import numpy as np
 import pandas as pd
 
 from utils.logging import get_logger
@@ -33,18 +34,18 @@ def standardize(df: pd.DataFrame) -> pd.DataFrame:
     df = df.sort_values("_ingested_at").drop_duplicates(
         subset=["asin", "site", "dt"], keep="last"
     )
-    price = pd.to_numeric(df["price"], errors="coerce")
-    bsr = pd.to_numeric(df["bsr"], errors="coerce")
-    rating = pd.to_numeric(df["rating"], errors="coerce")
+    price = pd.to_numeric(df["price"], errors="coerce").astype("float64")
+    bsr = pd.to_numeric(df["bsr"], errors="coerce").astype("float64")
+    rating = pd.to_numeric(df["rating"], errors="coerce").astype("float64")
 
     price_valid = price.notna() & (price > 0)
     bsr_valid = bsr.notna() & (bsr > 0) & (bsr < 5_000_000)
 
-    df["price_valid"] = price_valid
-    df["bsr_valid"] = bsr_valid
+    df["price_valid"] = price_valid.astype(bool)
+    df["bsr_valid"] = bsr_valid.astype(bool)
 
-    df["price"] = price.where(price_valid)
-    df["bsr"] = bsr.where(bsr_valid)
+    df["price"] = price.where(price_valid, np.nan)
+    df["bsr"] = bsr.where(bsr_valid, np.nan)
     df["rating"] = rating
     df["dt"] = pd.to_datetime(df["dt"]).dt.normalize()
     return df

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -42,6 +42,11 @@ def test_standardize_handles_duplicates_and_flags():
 
     result = run([raw])
     assert len(result) == 1
+    assert pd.api.types.is_float_dtype(result["price"])
+    assert pd.api.types.is_float_dtype(result["bsr"])
+    assert pd.api.types.is_float_dtype(result["rating"])
+    assert pd.api.types.is_bool_dtype(result["price_valid"])
+    assert pd.api.types.is_bool_dtype(result["bsr_valid"])
     row = result.iloc[0]
     assert bool(row["price_valid"])
     assert not row["bsr_valid"]


### PR DESCRIPTION
## Summary
- convert standardized price, bsr, and rating columns to floats while keeping validity flags boolean and masking invalid entries with NaN
- extend ETL regression coverage to assert column dtypes and ensure invalid BSR records flow through label building without errors

## Testing
- pytest tests/test_etl.py::test_standardize_handles_duplicates_and_flags
- pytest tests/test_etl.py::test_standardize_and_build_labels_handle_invalid_bsr

------
https://chatgpt.com/codex/tasks/task_e_68e0e3c63388832daeea14ef219c0e8a