### PR TITLE
Handle list metadata when serialising

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
+
 import pandas as pd
 
-from training.build_labels import _compute_rank_target
+from training.build_labels import _compute_rank_target, _normalise_for_json
 
 
 def test_highest_future_sales_receives_largest_rank() -> None:
@@ -17,3 +19,21 @@ def test_highest_future_sales_receives_largest_rank() -> None:
         ranked = _compute_rank_target(group)
         top_row = ranked.loc[group["future_sales"].idxmax()]
         assert top_row["y_rank"] == ranked["y_rank"].max(), asin
+
+
+def test_meta_serialised_as_string_round_trip() -> None:
+    meta = pd.Series(
+        [
+            {
+                "features": ["wireless", "bluetooth"],
+                "dimensions": {"width": 2.3, "height": [1, 2, None]},
+            },
+            {"features": []},
+        ]
+    )
+
+    serialised = meta.apply(lambda value: json.dumps(_normalise_for_json(value)))
+    round_tripped = serialised.apply(json.loads)
+    expected = meta.apply(_normalise_for_json)
+
+    assert list(round_tripped) == list(expected)

--- a/training/build_labels.py
+++ b/training/build_labels.py
@@ -1,6 +1,11 @@
 """Helpers for constructing supervised learning targets."""
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+import datetime as dt
+from typing import Any
+
+import numpy as np
 import pandas as pd
 
 
@@ -66,3 +71,58 @@ def _compute_rank_target(group: pd.DataFrame) -> pd.DataFrame:
 
     ranked["y_rank"] = (max_rank - order + 1) / max_rank
     return ranked
+
+
+def _normalise_for_json(value: Any) -> Any:
+    """Normalise objects so that they can be serialised via ``json.dumps``.
+
+    The helper mirrors the behaviour expected by the training jobs where
+    metadata values may include scalars, sequences or nested mappings. Pandas
+    ``isna`` cannot be called on list-like objects because it tries to evaluate
+    their truthiness which raises ``ValueError``. To avoid that we convert any
+    iterable structures before falling back to ``pd.isna`` for scalar values.
+    """
+
+    if value is None:
+        return None
+
+    if isinstance(value, (str, bytes, bytearray)):
+        return value
+
+    if isinstance(value, Mapping):
+        return {str(key): _normalise_for_json(item) for key, item in value.items()}
+
+    if isinstance(value, pd.Series):
+        return [_normalise_for_json(item) for item in value.tolist()]
+
+    if isinstance(value, pd.Index):
+        return [_normalise_for_json(item) for item in value.tolist()]
+
+    if isinstance(value, np.ndarray):
+        return [_normalise_for_json(item) for item in value.tolist()]
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_normalise_for_json(item) for item in list(value)]
+
+    if isinstance(value, set):
+        return [_normalise_for_json(item) for item in list(value)]
+
+    if isinstance(value, np.generic):
+        return value.item()
+
+    if isinstance(value, (pd.Timestamp, dt.datetime, dt.date)):
+        return value.isoformat()
+
+    if isinstance(value, pd.Timedelta):
+        return value.isoformat() if hasattr(value, "isoformat") else str(value)
+
+    try:
+        if pd.isna(value):
+            return None
+    except TypeError:
+        pass
+
+    if isinstance(value, (np.bool_,)):  # ``json`` cannot serialise numpy bools
+        return bool(value)
+
+    return value


### PR DESCRIPTION
## Summary
- normalise metadata structures containing lists or mappings before JSON serialisation
- add a regression test to ensure metadata JSON strings round-trip correctly

## Testing
- pytest tests/test_training.py

------
https://chatgpt.com/codex/tasks/task_e_68e0eacecbf8832dab35dd3c898078d8