### PR TITLE
Add model card template and governance instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,17 @@ The scoring pipeline materialises data into `score_baseline_daily`. Use the view
 | Frequent 429 responses | Lower QPM in `config/settings.yaml` or verify rate limiter tenant separation |
 | Missing daily rows | Inspect validator coverage report and raw payload counts |
 | Score volatility | Review site/category MAD values; adjust weights in settings if needed |
+
+## Model Card Governance
+
+- The canonical template lives in [`docs/model_card_template.md`](docs/model_card_template.md). Copy it
+  for each release (for example `docs/model_card_v1.2.0.md`) and replace the placeholders with the
+  latest training data, metrics, and approvals.
+- Update the **Change History** table in the published model card with a new row that captures the
+  release tag, deployment date, concise summary of behavioural changes, and the accountable owner.
+- Refresh the **Data Scope**, **Metrics**, **Known Limits**, and **Compliance & Governance** sections
+  using evidence from the release validation package (offline evaluation notebook, monitoring
+  dashboards, policy reviews).
+- After merging the release branch, drop the link to the updated model card into the analytics
+  registry or deployment tracker so downstream consumers can find it alongside the promoted model
+  artefacts.

--- a/docs/model_card_template.md
+++ b/docs/model_card_template.md
@@ -1,0 +1,35 @@
+# Model Card Template
+
+Use this template to document each production release of the Explosive Score model. Update the
+sections below with concise, factual information sourced from the most recent training run,
+validation report, and stakeholder review.
+
+## Data Scope
+- **Training sources:** Describe the datasets, collection windows, filtering rules, and notable
+  exclusions.
+- **Population coverage:** Clarify marketplaces, locales, ASIN segments, and any demographic or
+  product constraints.
+- **Update cadence:** Note refresh frequency, retraining schedule, and triggers for ad-hoc runs.
+
+## Metrics
+- **Core evaluation metrics:** Capture offline metrics (e.g., MAP@K, precision/recall, calibration).
+- **Monitoring signals:** List online KPIs or shadow deployment checks tracked post-release.
+- **Benchmark comparisons:** Summarise baselines or prior models used for reference.
+
+## Known Limits
+- **Data limitations:** Enumerate sampling gaps, reporting delays, or known anomalies.
+- **Model behaviour:** Highlight failure modes, bias considerations, and edge cases.
+- **Operational caveats:** Document dependencies that impact availability or quality.
+
+## Compliance & Governance
+- **Approvals:** Record sign-off stakeholders and dates (product, legal, compliance, DS lead).
+- **Policies:** Reference applicable governance, retention, and privacy requirements.
+- **Review cadence:** State audit frequency and links to the latest review artefacts.
+
+## Change History
+| Release | Date | Summary | Owner |
+| --- | --- | --- | --- |
+| vX.Y.Z | YYYY-MM-DD | Short description of changes and rationale | Name |
+
+> **Reminder:** Append a new row for every release and link to supporting analysis or dashboards
+> when available.


### PR DESCRIPTION
## Summary
- add a reusable model card template covering data scope, metrics, limits, compliance, and change history
- document the release workflow for refreshing the model card and surfacing links for consumers

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e15eac43dc832d86a14dd044bde4ba