### PR TITLE
Add training scripts for ranking and baseline models

### DIFF
--- a/training/eval_metrics.py
+++ b/training/eval_metrics.py
@@ -1,0 +1,172 @@
+"""Shared evaluation metrics utilities for training scripts."""
+from __future__ import annotations
+
+import math
+from typing import MutableMapping, Sequence
+
+import numpy as np
+
+
+ArrayLike = Sequence[float] | np.ndarray
+
+
+def _to_numpy(array: ArrayLike) -> np.ndarray:
+    if isinstance(array, np.ndarray):
+        return array.astype(float)
+    return np.asarray(list(array), dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# Ranking metrics
+# ---------------------------------------------------------------------------
+
+
+def dcg_at_k(relevance: np.ndarray, k: int) -> float:
+    if relevance.size == 0 or k <= 0:
+        return 0.0
+    topk = relevance[:k]
+    discounts = 1.0 / np.log2(np.arange(2, topk.size + 2))
+    gains = np.power(2.0, topk) - 1.0
+    return float(np.sum(gains * discounts))
+
+
+def ndcg_at_k(relevance: ArrayLike, ideal_relevance: ArrayLike | None = None, k: int = 20) -> float:
+    rel = _to_numpy(relevance)
+    ideal = _to_numpy(ideal_relevance) if ideal_relevance is not None else np.sort(rel)[::-1]
+    normaliser = dcg_at_k(ideal, k)
+    if normaliser == 0:
+        return 0.0
+    return dcg_at_k(rel, k) / normaliser
+
+
+def compute_ranking_metrics(
+    y_true: ArrayLike,
+    y_score: ArrayLike,
+    group: Sequence[int] | Sequence[str],
+    ks: Sequence[int] = (5, 10, 20),
+) -> dict[str, float]:
+    y_true_np = _to_numpy(y_true)
+    y_score_np = _to_numpy(y_score)
+    group_np = np.asarray(list(group))
+
+    metrics: MutableMapping[str, list[float]] = {f"ndcg@{k}": [] for k in ks}
+
+    for group_id in np.unique(group_np):
+        mask = group_np == group_id
+        group_true = y_true_np[mask]
+        group_scores = y_score_np[mask]
+        if group_true.size == 0:
+            continue
+        order = np.argsort(group_scores)[::-1]
+        sorted_true = group_true[order]
+        ideal_true = np.sort(group_true)[::-1]
+        for k in ks:
+            metrics[f"ndcg@{k}"].append(ndcg_at_k(sorted_true, ideal_true, k))
+
+    averaged = {metric: float(np.mean(values)) if values else float("nan") for metric, values in metrics.items()}
+    return averaged
+
+
+# ---------------------------------------------------------------------------
+# Binary classification metrics
+# ---------------------------------------------------------------------------
+
+
+def _binary_confusion(y_true: np.ndarray, y_pred: np.ndarray) -> tuple[int, int, int, int]:
+    tp = int(np.sum((y_true == 1) & (y_pred == 1)))
+    tn = int(np.sum((y_true == 0) & (y_pred == 0)))
+    fp = int(np.sum((y_true == 0) & (y_pred == 1)))
+    fn = int(np.sum((y_true == 1) & (y_pred == 0)))
+    return tp, tn, fp, fn
+
+
+def _binary_probabilities(y_pred_proba: ArrayLike) -> np.ndarray:
+    probs = _to_numpy(y_pred_proba)
+    if probs.ndim == 2 and probs.shape[1] == 2:
+        probs = probs[:, 1]
+    return np.clip(probs, 1e-15, 1 - 1e-15)
+
+
+def roc_auc_score(y_true: ArrayLike, y_score: ArrayLike) -> float:
+    y_true_np = _to_numpy(y_true)
+    y_score_np = _to_numpy(y_score)
+    pos = y_true_np == 1
+    neg = y_true_np == 0
+    n_pos = int(np.sum(pos))
+    n_neg = int(np.sum(neg))
+    if n_pos == 0 or n_neg == 0:
+        return float("nan")
+    order = np.argsort(y_score_np)
+    ranks = np.empty_like(order, dtype=float)
+    ranks[order] = np.arange(1, len(y_score_np) + 1)
+    sum_ranks_pos = np.sum(ranks[pos])
+    auc = (sum_ranks_pos - n_pos * (n_pos + 1) / 2) / (n_pos * n_neg)
+    return float(auc)
+
+
+def log_loss(y_true: ArrayLike, y_pred_proba: ArrayLike) -> float:
+    y_true_np = _to_numpy(y_true)
+    probs = _binary_probabilities(y_pred_proba)
+    losses = y_true_np * np.log(probs) + (1 - y_true_np) * np.log(1 - probs)
+    return float(-np.mean(losses))
+
+
+def binary_classification_metrics(
+    y_true: ArrayLike,
+    y_pred_proba: ArrayLike,
+    threshold: float = 0.5,
+) -> dict[str, float]:
+    y_true_np = _to_numpy(y_true)
+    probs = _binary_probabilities(y_pred_proba)
+    preds = (probs >= threshold).astype(int)
+
+    tp, tn, fp, fn = _binary_confusion(y_true_np, preds)
+    total = tp + tn + fp + fn
+    accuracy = (tp + tn) / total if total else float("nan")
+    precision = tp / (tp + fp) if (tp + fp) else float("nan")
+    recall = tp / (tp + fn) if (tp + fn) else float("nan")
+    f1 = 2 * precision * recall / (precision + recall) if precision and recall else float("nan")
+    specificity = tn / (tn + fp) if (tn + fp) else float("nan")
+    balanced_accuracy = (recall + specificity) / 2 if not math.isnan(recall) and not math.isnan(specificity) else float("nan")
+
+    metrics = {
+        "accuracy": float(accuracy),
+        "precision": float(precision) if not math.isnan(precision) else float("nan"),
+        "recall": float(recall) if not math.isnan(recall) else float("nan"),
+        "f1": float(f1) if not math.isnan(f1) else float("nan"),
+        "balanced_accuracy": float(balanced_accuracy) if not math.isnan(balanced_accuracy) else float("nan"),
+        "roc_auc": roc_auc_score(y_true_np, probs),
+        "log_loss": log_loss(y_true_np, probs),
+    }
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Regression metrics
+# ---------------------------------------------------------------------------
+
+
+def regression_metrics(y_true: ArrayLike, y_pred: ArrayLike) -> dict[str, float]:
+    y_true_np = _to_numpy(y_true)
+    y_pred_np = _to_numpy(y_pred)
+    diff = y_true_np - y_pred_np
+    mse = float(np.mean(np.square(diff)))
+    rmse = math.sqrt(mse)
+    mae = float(np.mean(np.abs(diff)))
+    if y_true_np.size == 0:
+        r2 = float("nan")
+    else:
+        total_var = float(np.sum(np.square(y_true_np - np.mean(y_true_np))))
+        r2 = 1 - (np.sum(np.square(diff)) / total_var) if total_var else float("nan")
+    return {"rmse": rmse, "mae": mae, "mse": mse, "r2": float(r2)}
+
+
+__all__ = [
+    "binary_classification_metrics",
+    "regression_metrics",
+    "compute_ranking_metrics",
+    "ndcg_at_k",
+    "roc_auc_score",
+    "log_loss",
+]
+

--- a/training/run_logger.py
+++ b/training/run_logger.py
@@ -1,0 +1,143 @@
+"""Utility helpers for logging experiment runs.
+
+The project prefers MLflow for tracking but the dependency is optional in the
+test environment. ``RunLogger`` therefore attempts to initialise MLflow and
+falls back to writing structured files under a ``runs/`` directory when MLflow
+is not available. The interface mimics the subset of the MLflow API used by the
+training scripts so that the calling code does not have to branch on the
+tracking backend being available.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import logging
+from pathlib import Path
+import shutil
+import tempfile
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _serialise_json(data: Any) -> str:
+    return json.dumps(data, indent=2, sort_keys=True, default=str)
+
+
+@dataclass
+class _FileRunStore:
+    """Persist run metadata to the filesystem when MLflow is unavailable."""
+
+    base_dir: Path
+    params: MutableMapping[str, Any] = field(default_factory=dict)
+    metrics: list[Mapping[str, Any]] = field(default_factory=list)
+
+    def log_params(self, params: Mapping[str, Any]) -> None:
+        self.params.update(params)
+        self._write_file("params.json", self.params)
+
+    def log_metrics(self, metrics: Mapping[str, Any], step: Optional[int]) -> None:
+        entry = {"step": step, **metrics}
+        self.metrics.append(entry)
+        self._write_file("metrics.json", self.metrics)
+
+    def log_artifact(self, path: Path) -> None:
+        destination = self.base_dir / path.name
+        if path.resolve() == destination.resolve():
+            return
+        if path.is_dir():
+            if destination.exists():
+                shutil.rmtree(destination)
+            shutil.copytree(path, destination)
+        else:
+            shutil.copy2(path, destination)
+
+    def log_text(self, text: str, artifact_file: str) -> None:
+        target_path = self.base_dir / artifact_file
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(text, encoding="utf-8")
+
+    def _write_file(self, filename: str, data: Any) -> None:
+        target_path = self.base_dir / filename
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        content = _serialise_json(data if isinstance(data, Mapping) else data)
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as tmp:
+            tmp.write(content)
+            temp_path = Path(tmp.name)
+        temp_path.replace(target_path)
+
+
+class RunLogger:
+    """Context manager mirroring a subset of the MLflow run interface."""
+
+    def __init__(
+        self,
+        experiment: str,
+        run_name: Optional[str] = None,
+        tracking_uri: Optional[str] = None,
+        output_dir: Path | str = Path("runs"),
+    ) -> None:
+        self.experiment = experiment
+        self.run_name = run_name
+        self.tracking_uri = tracking_uri
+        self.output_dir = Path(output_dir)
+        self._mlflow_run = None
+        self._mlflow = None
+        self._file_store: Optional[_FileRunStore] = None
+
+    def __enter__(self) -> "RunLogger":
+        try:
+            import mlflow
+
+            if self.tracking_uri:
+                mlflow.set_tracking_uri(self.tracking_uri)
+            mlflow.set_experiment(self.experiment)
+            self._mlflow = mlflow
+            self._mlflow_run = mlflow.start_run(run_name=self.run_name)
+            LOGGER.info("Started MLflow run: %s", self._mlflow_run.info.run_id)
+        except Exception as exc:  # pragma: no cover - fallback path
+            LOGGER.info("Falling back to filesystem run logging: %s", exc)
+            run_name = self.run_name or "run"
+            run_dir = self.output_dir / self.experiment / run_name
+            run_dir.mkdir(parents=True, exist_ok=True)
+            self._file_store = _FileRunStore(run_dir)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        if self._mlflow is not None:
+            self._mlflow.end_run(status="FAILED" if exc else "FINISHED")
+
+    # ------------------------------------------------------------------
+    # Public logging helpers
+    # ------------------------------------------------------------------
+    def log_params(self, params: Mapping[str, Any]) -> None:
+        if self._mlflow is not None:
+            self._mlflow.log_params(params)
+        elif self._file_store is not None:
+            self._file_store.log_params(params)
+
+    def log_metrics(self, metrics: Mapping[str, Any], step: Optional[int] = None) -> None:
+        if self._mlflow is not None:
+            self._mlflow.log_metrics(metrics, step=step)
+        elif self._file_store is not None:
+            self._file_store.log_metrics(metrics, step)
+
+    def log_artifact(self, path: Path) -> None:
+        if self._mlflow is not None:
+            self._mlflow.log_artifact(str(path))
+        elif self._file_store is not None:
+            self._file_store.log_artifact(path)
+
+    def log_text(self, text: str, artifact_file: str) -> None:
+        if self._mlflow is not None:
+            self._mlflow.log_text(text, artifact_file)
+        elif self._file_store is not None:
+            self._file_store.log_text(text, artifact_file)
+
+    def set_tags(self, tags: Mapping[str, Any]) -> None:
+        if self._mlflow is not None:
+            self._mlflow.set_tags(tags)
+        elif self._file_store is not None:
+            self._file_store.log_params({f"tag.{key}": value for key, value in tags.items()})
+

--- a/training/train_cls.py
+++ b/training/train_cls.py
@@ -1,0 +1,326 @@
+"""Binary classification baselines using gradient boosting libraries."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from training.eval_metrics import binary_classification_metrics
+from training.run_logger import RunLogger
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _read_frame(path: Path) -> pd.DataFrame:
+    if path.suffix.lower() == ".parquet":
+        return pd.read_parquet(path)
+    if path.suffix.lower() in {".csv", ".txt"}:
+        return pd.read_csv(path)
+    raise ValueError(f"Unsupported file type: {path.suffix}")
+
+
+def _load_dataset(path: Path) -> pd.DataFrame:
+    if path.is_file():
+        return _read_frame(path)
+    frames = []
+    for file in sorted(path.glob("*")):
+        if file.suffix.lower() not in {".csv", ".parquet", ".txt"}:
+            continue
+        frames.append(_read_frame(file))
+    if not frames:
+        raise FileNotFoundError(f"No compatible training files located in {path}")
+    return pd.concat(frames, ignore_index=True)
+
+
+def _prepare_features(df: pd.DataFrame, target_col: str, drop_columns: Sequence[str]) -> pd.DataFrame:
+    excluded = {target_col, *drop_columns}
+    features = [col for col in df.columns if col not in excluded and pd.api.types.is_numeric_dtype(df[col])]
+    if not features:
+        raise ValueError("No numeric features available for classification training")
+    return df[features]
+
+
+def _stratified_split(df: pd.DataFrame, target_col: str, test_size: float, random_state: int) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rng = np.random.default_rng(random_state)
+    indices = np.arange(len(df))
+    test_indices: list[int] = []
+
+    for cls, cls_indices in df.groupby(target_col).groups.items():
+        cls_indices = np.asarray(cls_indices)
+        cls_indices = cls_indices[rng.permutation(len(cls_indices))]
+        n_test = max(1, int(np.ceil(len(cls_indices) * test_size))) if len(cls_indices) > 1 else 1
+        test_indices.extend(cls_indices[:n_test])
+
+    test_mask = np.zeros(len(df), dtype=bool)
+    test_mask[test_indices] = True
+    train_df = df.loc[~test_mask].copy()
+    test_df = df.loc[test_mask].copy()
+    if train_df.empty or test_df.empty:
+        raise ValueError("Stratified split produced empty partition; adjust test size")
+    return train_df, test_df
+
+
+def _train_lightgbm(train_X, train_y, val_X, val_y, args, class_weight: float | None):
+    try:
+        import lightgbm as lgb
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("LightGBM must be installed for lightgbm model") from exc
+
+    params = {
+        "objective": "binary",
+        "metric": ["binary_logloss", "auc"],
+        "learning_rate": args.learning_rate,
+        "num_leaves": args.num_leaves,
+        "min_data_in_leaf": args.min_data_in_leaf,
+        "feature_fraction": args.feature_fraction,
+        "bagging_fraction": args.bagging_fraction,
+        "bagging_freq": 1,
+        "lambda_l2": args.lambda_l2,
+        "random_state": args.random_state,
+        "verbose": -1,
+    }
+    if class_weight:
+        params["scale_pos_weight"] = class_weight
+
+    train_dataset = lgb.Dataset(train_X, label=train_y)
+    val_dataset = lgb.Dataset(val_X, label=val_y, reference=train_dataset)
+
+    booster = lgb.train(
+        params,
+        train_set=train_dataset,
+        valid_sets=[train_dataset, val_dataset],
+        valid_names=["train", "validation"],
+        num_boost_round=args.num_boost_round,
+        early_stopping_rounds=args.early_stopping_rounds,
+        verbose_eval=args.verbose_eval,
+    )
+
+    best_iteration = booster.best_iteration or args.num_boost_round
+    train_pred = booster.predict(train_X, num_iteration=best_iteration)
+    val_pred = booster.predict(val_X, num_iteration=best_iteration)
+    feature_importances = pd.DataFrame(
+        {
+            "feature": train_X.columns,
+            "gain": booster.feature_importance(importance_type="gain"),
+            "split": booster.feature_importance(importance_type="split"),
+        }
+    ).sort_values("gain", ascending=False)
+
+    return booster, train_pred, val_pred, feature_importances
+
+
+def _train_xgboost(train_X, train_y, val_X, val_y, args, class_weight: float | None):
+    try:
+        import xgboost as xgb
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("XGBoost must be installed for xgboost model") from exc
+
+    dtrain = xgb.DMatrix(train_X, label=train_y)
+    dval = xgb.DMatrix(val_X, label=val_y)
+    params = {
+        "objective": "binary:logistic",
+        "eval_metric": "logloss",
+        "eta": args.learning_rate,
+        "max_depth": args.max_depth,
+        "subsample": args.bagging_fraction,
+        "colsample_bytree": args.feature_fraction,
+        "lambda": args.lambda_l2,
+        "gamma": 0.0,
+        "min_child_weight": args.min_data_in_leaf,
+        "seed": args.random_state,
+    }
+    if class_weight:
+        params["scale_pos_weight"] = class_weight
+
+    evals_result: dict[str, list[float]] = {}
+    booster = xgb.train(
+        params,
+        dtrain,
+        num_boost_round=args.num_boost_round,
+        evals=[(dtrain, "train"), (dval, "validation")],
+        early_stopping_rounds=args.early_stopping_rounds,
+        evals_result=evals_result,
+        verbose_eval=args.verbose_eval,
+    )
+
+    best_ntree = booster.best_ntree_limit or args.num_boost_round
+    train_pred = booster.predict(dtrain, ntree_limit=best_ntree)
+    val_pred = booster.predict(dval, ntree_limit=best_ntree)
+    importance = booster.get_score(importance_type="gain")
+    feature_importances = pd.DataFrame(
+        {
+            "feature": list(importance.keys()),
+            "gain": list(importance.values()),
+        }
+    ).sort_values("gain", ascending=False)
+
+    return booster, train_pred, val_pred, feature_importances
+
+
+def _train_catboost(train_X, train_y, val_X, val_y, args, class_weight: float | None):
+    try:
+        from catboost import CatBoostClassifier, Pool
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("CatBoost must be installed for catboost model") from exc
+
+    model = CatBoostClassifier(
+        iterations=args.num_boost_round,
+        learning_rate=args.learning_rate,
+        depth=args.max_depth,
+        l2_leaf_reg=args.lambda_l2,
+        loss_function="Logloss",
+        eval_metric="Logloss",
+        random_seed=args.random_state,
+        verbose=False,
+        early_stopping_rounds=args.early_stopping_rounds,
+        auto_class_weights="Balanced" if class_weight else None,
+    )
+
+    train_pool = Pool(train_X, label=train_y)
+    val_pool = Pool(val_X, label=val_y)
+    model.fit(train_pool, eval_set=val_pool, verbose=args.verbose_eval)
+
+    train_pred = model.predict_proba(train_X)[:, 1]
+    val_pred = model.predict_proba(val_X)[:, 1]
+    feature_importances = pd.DataFrame(
+        {
+            "feature": train_X.columns,
+            "importance": model.get_feature_importance(train_pool),
+        }
+    ).sort_values("importance", ascending=False)
+
+    return model, train_pred, val_pred, feature_importances
+
+
+MODEL_TRAINERS = {
+    "lightgbm": _train_lightgbm,
+    "xgboost": _train_xgboost,
+    "catboost": _train_catboost,
+}
+
+
+def train_model(args: argparse.Namespace) -> dict[str, float]:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    data_path = Path(args.data_path)
+    df = _load_dataset(data_path)
+    if args.target_column not in df.columns:
+        raise KeyError(f"Target column {args.target_column!r} not found in dataset")
+
+    drop_columns = set(args.drop_columns or [])
+    train_df, val_df = _stratified_split(df, args.target_column, args.validation_fraction, args.random_state)
+    train_features = _prepare_features(train_df, args.target_column, drop_columns)
+    val_features = _prepare_features(val_df, args.target_column, drop_columns)
+
+    pos = (train_df[args.target_column] == 1).sum()
+    neg = (train_df[args.target_column] == 0).sum()
+    class_weight = (neg / pos) if pos and neg else None
+
+    trainer = MODEL_TRAINERS.get(args.model_type)
+    if trainer is None:
+        raise ValueError(f"Unsupported model type: {args.model_type}")
+
+    model, train_pred, val_pred, feature_importances = trainer(
+        train_features,
+        train_df[args.target_column],
+        val_features,
+        val_df[args.target_column],
+        args,
+        class_weight,
+    )
+
+    train_metrics = binary_classification_metrics(train_df[args.target_column], train_pred)
+    val_metrics = binary_classification_metrics(val_df[args.target_column], val_pred)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics = {"train": train_metrics, "validation": val_metrics}
+
+    with RunLogger(args.experiment_name, args.run_name) as run:
+        run.log_params(
+            {
+                "model_type": args.model_type,
+                "learning_rate": args.learning_rate,
+                "num_boost_round": args.num_boost_round,
+                "num_leaves": args.num_leaves,
+                "max_depth": args.max_depth,
+                "min_data_in_leaf": args.min_data_in_leaf,
+                "feature_fraction": args.feature_fraction,
+                "bagging_fraction": args.bagging_fraction,
+                "lambda_l2": args.lambda_l2,
+                "class_weight": class_weight,
+            }
+        )
+        run.log_metrics({f"train_{k}": v for k, v in train_metrics.items()})
+        run.log_metrics({f"validation_{k}": v for k, v in val_metrics.items()})
+
+        feature_path = output_dir / f"{args.model_type}_feature_importances.csv"
+        feature_importances.to_csv(feature_path, index=False)
+        run.log_artifact(feature_path)
+
+        preds_path = output_dir / f"{args.model_type}_validation_predictions.csv"
+        pd.DataFrame(
+            {
+                "prediction": val_pred,
+                "label": val_df[args.target_column].to_numpy(),
+            }
+        ).to_csv(preds_path, index=False)
+        run.log_artifact(preds_path)
+
+        metrics_path = output_dir / f"{args.model_type}_metrics.json"
+        metrics_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+        run.log_artifact(metrics_path)
+
+    # Persist model if possible
+    model_path = output_dir / f"{args.model_type}_model"
+    try:
+        if hasattr(model, "save_model"):
+            model.save_model(str(model_path))  # type: ignore[attr-defined]
+        elif hasattr(model, "save_model_to_file"):
+            model.save_model_to_file(str(model_path))  # CatBoost compatibility
+    except Exception as exc:  # pragma: no cover - best effort persistence
+        LOGGER.warning("Failed to persist model artifact: %s", exc)
+
+    return val_metrics
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train binary classification baseline")
+    parser.add_argument("--data-path", type=str, default="train_samples_cls")
+    parser.add_argument("--output-dir", type=str, default="artifacts/cls")
+    parser.add_argument("--experiment-name", type=str, default="classification-baseline")
+    parser.add_argument("--run-name", type=str, default="run")
+    parser.add_argument("--target-column", type=str, default="label")
+    parser.add_argument("--drop-columns", nargs="*", default=None)
+    parser.add_argument("--validation-fraction", type=float, default=0.2)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--model-type", type=str, default="lightgbm", choices=list(MODEL_TRAINERS.keys()))
+    parser.add_argument("--learning-rate", type=float, default=0.05)
+    parser.add_argument("--num-boost-round", type=int, default=500)
+    parser.add_argument("--early-stopping-rounds", type=int, default=50)
+    parser.add_argument("--verbose-eval", type=int, default=50)
+    parser.add_argument("--num-leaves", type=int, default=63)
+    parser.add_argument("--max-depth", type=int, default=6)
+    parser.add_argument("--min-data-in-leaf", type=int, default=20)
+    parser.add_argument("--feature-fraction", type=float, default=0.8)
+    parser.add_argument("--bagging-fraction", type=float, default=0.8)
+    parser.add_argument("--lambda-l2", type=float, default=1.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    val_metrics = train_model(args)
+    LOGGER.info("Validation metrics: %s", val_metrics)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/training/train_rank.py
+++ b/training/train_rank.py
@@ -1,0 +1,273 @@
+"""Train a LambdaRank model using LightGBM."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+from training.eval_metrics import compute_ranking_metrics
+from training.run_logger import RunLogger
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _read_frame(path: Path) -> pd.DataFrame:
+    if path.suffix.lower() == ".parquet":
+        return pd.read_parquet(path)
+    if path.suffix.lower() in {".csv", ".txt"}:
+        return pd.read_csv(path)
+    raise ValueError(f"Unsupported file format: {path.suffix}")
+
+
+def _load_rank_data(data_path: Path) -> pd.DataFrame:
+    if not data_path.exists():
+        raise FileNotFoundError(f"No training data found at {data_path}")
+    if data_path.is_file():
+        return _read_frame(data_path)
+
+    frames = []
+    for file in sorted(data_path.glob("*")):
+        if file.suffix.lower() not in {".csv", ".parquet", ".txt"}:
+            continue
+        frames.append(_read_frame(file))
+    if not frames:
+        raise FileNotFoundError(f"No compatible files found in {data_path}")
+    return pd.concat(frames, ignore_index=True)
+
+
+def _detect_group_column(df: pd.DataFrame, provided: str | None) -> str:
+    if provided and provided in df.columns:
+        return provided
+    for candidate in ("group_id", "query", "query_id", "asin", "item_group"):
+        if candidate in df.columns:
+            return candidate
+    raise KeyError("Unable to determine group column; please specify explicitly")
+
+
+def _detect_label_column(df: pd.DataFrame, provided: str | None) -> str:
+    if provided and provided in df.columns:
+        return provided
+    for candidate in ("y_rank", "label", "target", "relevance"):
+        if candidate in df.columns:
+            return candidate
+    raise KeyError("Unable to determine label column; please specify explicitly")
+
+
+def _prepare_features(
+    df: pd.DataFrame,
+    label_col: str,
+    group_col: str,
+    drop_columns: Sequence[str],
+) -> pd.DataFrame:
+    excluded = {label_col, group_col, *drop_columns}
+    features = [
+        col
+        for col in df.columns
+        if col not in excluded and pd.api.types.is_numeric_dtype(df[col])
+    ]
+    if not features:
+        raise ValueError("No numeric features found for training")
+    return df[features]
+
+
+def _group_sizes(groups: Iterable) -> list[int]:
+    sizes: list[int] = []
+    current = None
+    count = 0
+    for item in groups:
+        if current is None:
+            current = item
+            count = 1
+            continue
+        if item == current:
+            count += 1
+        else:
+            sizes.append(count)
+            current = item
+            count = 1
+    if current is not None:
+        sizes.append(count)
+    return sizes
+
+
+def _train_validation_split(
+    df: pd.DataFrame,
+    group_col: str,
+    validation_fraction: float,
+    random_state: int,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rng = np.random.default_rng(random_state)
+    groups = df[group_col].drop_duplicates().to_numpy()
+    permutation = rng.permutation(len(groups))
+    n_val = max(1, int(np.ceil(len(groups) * validation_fraction)))
+    val_groups = set(groups[permutation[:n_val]])
+    train_df = df[~df[group_col].isin(val_groups)].copy()
+    val_df = df[df[group_col].isin(val_groups)].copy()
+    if train_df.empty or val_df.empty:
+        raise ValueError("Validation split produced empty dataset; adjust fraction")
+    return train_df, val_df
+
+
+def _build_dataset(
+    features: pd.DataFrame,
+    labels: pd.Series,
+    groups: pd.Series,
+    weights: pd.Series | None = None,
+):
+    try:
+        import lightgbm as lgb
+    except ImportError as exc:  # pragma: no cover - depends on optional dependency
+        raise ImportError("LightGBM is required for ranking training") from exc
+
+    group_sizes = _group_sizes(groups.to_numpy())
+    dataset = lgb.Dataset(features, label=labels, group=group_sizes, weight=weights)
+    return dataset
+
+
+def train_model(args: argparse.Namespace) -> dict[str, float]:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    data_path = Path(args.data_path)
+    df = _load_rank_data(data_path)
+    group_col = _detect_group_column(df, args.group_column)
+    label_col = _detect_label_column(df, args.label_column)
+    weight_col = args.weight_column if args.weight_column and args.weight_column in df.columns else None
+
+    train_df, val_df = _train_validation_split(df, group_col, args.validation_fraction, args.random_state)
+
+    drop_columns = set(args.drop_columns or [])
+    train_df = train_df.sort_values(group_col).reset_index(drop=True)
+    val_df = val_df.sort_values(group_col).reset_index(drop=True)
+
+    train_features = _prepare_features(train_df, label_col, group_col, drop_columns)
+    val_features = _prepare_features(val_df, label_col, group_col, drop_columns)
+
+    try:
+        import lightgbm as lgb
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("LightGBM must be installed to run ranking training") from exc
+
+    default_params = {
+        "objective": "lambdarank",
+        "metric": "ndcg",
+        "ndcg_at": [5, 10, 20],
+        "learning_rate": args.learning_rate,
+        "num_leaves": args.num_leaves,
+        "min_data_in_leaf": args.min_data_in_leaf,
+        "feature_fraction": args.feature_fraction,
+        "bagging_fraction": args.bagging_fraction,
+        "bagging_freq": 1,
+        "lambda_l2": args.lambda_l2,
+        "random_state": args.random_state,
+        "verbose": -1,
+    }
+
+    train_dataset = _build_dataset(
+        train_features,
+        train_df[label_col],
+        train_df[group_col],
+        train_df[weight_col] if weight_col else None,
+    )
+    val_dataset = _build_dataset(
+        val_features,
+        val_df[label_col],
+        val_df[group_col],
+        val_df[weight_col] if weight_col else None,
+    )
+
+    evals_result: dict[str, dict[str, list[float]]] = {}
+
+    with RunLogger(args.experiment_name, args.run_name) as run:
+        run.log_params(default_params)
+        run.set_tags({"data_path": str(data_path), "group_column": group_col, "label_column": label_col})
+
+        booster = lgb.train(
+            default_params,
+            train_set=train_dataset,
+            valid_sets=[train_dataset, val_dataset],
+            valid_names=["train", "validation"],
+            evals_result=evals_result,
+            num_boost_round=args.num_boost_round,
+            early_stopping_rounds=args.early_stopping_rounds,
+            verbose_eval=args.verbose_eval,
+        )
+
+        best_iteration = booster.best_iteration or args.num_boost_round
+        LOGGER.info("Best iteration: %s", best_iteration)
+
+        val_predictions = booster.predict(val_features, num_iteration=best_iteration)
+        ranking_metrics = compute_ranking_metrics(val_df[label_col], val_predictions, val_df[group_col], ks=(5, 10, 20, 50))
+        run.log_metrics(ranking_metrics)
+
+        feature_importances = pd.DataFrame(
+            {
+                "feature": train_features.columns,
+                "gain": booster.feature_importance(importance_type="gain"),
+                "split": booster.feature_importance(importance_type="split"),
+            }
+        ).sort_values("gain", ascending=False)
+        feature_path = Path(args.output_dir) / "feature_importances.csv"
+        feature_path.parent.mkdir(parents=True, exist_ok=True)
+        feature_importances.to_csv(feature_path, index=False)
+        run.log_artifact(feature_path)
+
+        shap_sample = min(len(val_features), args.shap_sample_size)
+        if shap_sample > 0:
+            sample = val_features.sample(n=shap_sample, random_state=args.random_state)
+            shap_values = booster.predict(sample, num_iteration=best_iteration, pred_contrib=True)
+            shap_df = pd.DataFrame(shap_values, columns=list(sample.columns) + ["bias"])
+            shap_path = Path(args.output_dir) / "shap_values.csv"
+            shap_df.to_csv(shap_path, index=False)
+            run.log_artifact(shap_path)
+
+        model_path = Path(args.output_dir) / "model.txt"
+        booster.save_model(model_path)
+        run.log_artifact(model_path)
+
+        metrics_path = Path(args.output_dir) / "metrics.json"
+        metrics_path.write_text(json.dumps(ranking_metrics, indent=2), encoding="utf-8")
+        run.log_artifact(metrics_path)
+
+    return ranking_metrics
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train LightGBM LambdaRank model")
+    parser.add_argument("--data-path", type=str, default="train_samples_rank", help="Path to training samples directory or file")
+    parser.add_argument("--output-dir", type=str, default="artifacts/rank", help="Directory to store model artifacts")
+    parser.add_argument("--experiment-name", type=str, default="rank-training", help="Experiment name for MLflow or local logging")
+    parser.add_argument("--run-name", type=str, default="run", help="Run name for logging")
+    parser.add_argument("--group-column", type=str, default=None, help="Column containing group identifiers")
+    parser.add_argument("--label-column", type=str, default=None, help="Column containing rank labels")
+    parser.add_argument("--weight-column", type=str, default=None, help="Optional sample weight column")
+    parser.add_argument("--drop-columns", nargs="*", default=None, help="Additional columns to drop from features")
+    parser.add_argument("--validation-fraction", type=float, default=0.2, help="Fraction of groups used for validation")
+    parser.add_argument("--random-state", type=int, default=42, help="Random seed for deterministic behaviour")
+    parser.add_argument("--learning-rate", type=float, default=0.05)
+    parser.add_argument("--num-leaves", type=int, default=63)
+    parser.add_argument("--min-data-in-leaf", type=int, default=20)
+    parser.add_argument("--feature-fraction", type=float, default=0.8)
+    parser.add_argument("--bagging-fraction", type=float, default=0.8)
+    parser.add_argument("--lambda-l2", type=float, default=1.0)
+    parser.add_argument("--num-boost-round", type=int, default=1000)
+    parser.add_argument("--early-stopping-rounds", type=int, default=50)
+    parser.add_argument("--verbose-eval", type=int, default=50)
+    parser.add_argument("--shap-sample-size", type=int, default=200)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    metrics = train_model(args)
+    LOGGER.info("Validation metrics: %s", metrics)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/training/train_reg.py
+++ b/training/train_reg.py
@@ -1,0 +1,305 @@
+"""Regression baselines using gradient boosting libraries."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from training.eval_metrics import regression_metrics
+from training.run_logger import RunLogger
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _read_frame(path: Path) -> pd.DataFrame:
+    if path.suffix.lower() == ".parquet":
+        return pd.read_parquet(path)
+    if path.suffix.lower() in {".csv", ".txt"}:
+        return pd.read_csv(path)
+    raise ValueError(f"Unsupported file type: {path.suffix}")
+
+
+def _load_dataset(path: Path) -> pd.DataFrame:
+    if path.is_file():
+        return _read_frame(path)
+    frames = []
+    for file in sorted(path.glob("*")):
+        if file.suffix.lower() not in {".csv", ".parquet", ".txt"}:
+            continue
+        frames.append(_read_frame(file))
+    if not frames:
+        raise FileNotFoundError(f"No compatible files located in {path}")
+    return pd.concat(frames, ignore_index=True)
+
+
+def _prepare_features(df: pd.DataFrame, target_col: str, drop_columns: Sequence[str]) -> pd.DataFrame:
+    excluded = {target_col, *drop_columns}
+    features = [col for col in df.columns if col not in excluded and pd.api.types.is_numeric_dtype(df[col])]
+    if not features:
+        raise ValueError("No numeric features available for regression training")
+    return df[features]
+
+
+def _train_validation_split(df: pd.DataFrame, test_size: float, random_state: int) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rng = np.random.default_rng(random_state)
+    indices = np.arange(len(df))
+    rng.shuffle(indices)
+    n_test = max(1, int(np.ceil(len(df) * test_size)))
+    test_indices = indices[:n_test]
+    train_indices = indices[n_test:]
+    train_df = df.iloc[train_indices].copy()
+    test_df = df.iloc[test_indices].copy()
+    if train_df.empty or test_df.empty:
+        raise ValueError("Validation split produced empty partition; adjust fraction")
+    return train_df, test_df
+
+
+def _train_lightgbm(train_X, train_y, val_X, val_y, args):
+    try:
+        import lightgbm as lgb
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError("LightGBM must be installed for lightgbm model") from exc
+
+    params = {
+        "objective": "regression",
+        "metric": ["rmse"],
+        "learning_rate": args.learning_rate,
+        "num_leaves": args.num_leaves,
+        "min_data_in_leaf": args.min_data_in_leaf,
+        "feature_fraction": args.feature_fraction,
+        "bagging_fraction": args.bagging_fraction,
+        "bagging_freq": 1,
+        "lambda_l2": args.lambda_l2,
+        "random_state": args.random_state,
+        "verbose": -1,
+    }
+
+    train_dataset = lgb.Dataset(train_X, label=train_y)
+    val_dataset = lgb.Dataset(val_X, label=val_y, reference=train_dataset)
+
+    booster = lgb.train(
+        params,
+        train_set=train_dataset,
+        valid_sets=[train_dataset, val_dataset],
+        valid_names=["train", "validation"],
+        num_boost_round=args.num_boost_round,
+        early_stopping_rounds=args.early_stopping_rounds,
+        verbose_eval=args.verbose_eval,
+    )
+
+    best_iteration = booster.best_iteration or args.num_boost_round
+    train_pred = booster.predict(train_X, num_iteration=best_iteration)
+    val_pred = booster.predict(val_X, num_iteration=best_iteration)
+    feature_importances = pd.DataFrame(
+        {
+            "feature": train_X.columns,
+            "gain": booster.feature_importance(importance_type="gain"),
+            "split": booster.feature_importance(importance_type="split"),
+        }
+    ).sort_values("gain", ascending=False)
+
+    return booster, train_pred, val_pred, feature_importances
+
+
+def _train_xgboost(train_X, train_y, val_X, val_y, args):
+    try:
+        import xgboost as xgb
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError("XGBoost must be installed for xgboost model") from exc
+
+    dtrain = xgb.DMatrix(train_X, label=train_y)
+    dval = xgb.DMatrix(val_X, label=val_y)
+    params = {
+        "objective": "reg:squarederror",
+        "eval_metric": "rmse",
+        "eta": args.learning_rate,
+        "max_depth": args.max_depth,
+        "subsample": args.bagging_fraction,
+        "colsample_bytree": args.feature_fraction,
+        "lambda": args.lambda_l2,
+        "min_child_weight": args.min_data_in_leaf,
+        "seed": args.random_state,
+    }
+
+    booster = xgb.train(
+        params,
+        dtrain,
+        num_boost_round=args.num_boost_round,
+        evals=[(dtrain, "train"), (dval, "validation")],
+        early_stopping_rounds=args.early_stopping_rounds,
+        verbose_eval=args.verbose_eval,
+    )
+
+    best_ntree = booster.best_ntree_limit or args.num_boost_round
+    train_pred = booster.predict(dtrain, ntree_limit=best_ntree)
+    val_pred = booster.predict(dval, ntree_limit=best_ntree)
+    importance = booster.get_score(importance_type="gain")
+    feature_importances = pd.DataFrame(
+        {
+            "feature": list(importance.keys()),
+            "gain": list(importance.values()),
+        }
+    ).sort_values("gain", ascending=False)
+
+    return booster, train_pred, val_pred, feature_importances
+
+
+def _train_catboost(train_X, train_y, val_X, val_y, args):
+    try:
+        from catboost import CatBoostRegressor, Pool
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError("CatBoost must be installed for catboost model") from exc
+
+    model = CatBoostRegressor(
+        iterations=args.num_boost_round,
+        learning_rate=args.learning_rate,
+        depth=args.max_depth,
+        l2_leaf_reg=args.lambda_l2,
+        loss_function="RMSE",
+        eval_metric="RMSE",
+        random_seed=args.random_state,
+        verbose=False,
+        early_stopping_rounds=args.early_stopping_rounds,
+    )
+
+    train_pool = Pool(train_X, label=train_y)
+    val_pool = Pool(val_X, label=val_y)
+    model.fit(train_pool, eval_set=val_pool, verbose=args.verbose_eval)
+
+    train_pred = model.predict(train_X)
+    val_pred = model.predict(val_X)
+    feature_importances = pd.DataFrame(
+        {
+            "feature": train_X.columns,
+            "importance": model.get_feature_importance(train_pool),
+        }
+    ).sort_values("importance", ascending=False)
+
+    return model, train_pred, val_pred, feature_importances
+
+
+MODEL_TRAINERS = {
+    "lightgbm": _train_lightgbm,
+    "xgboost": _train_xgboost,
+    "catboost": _train_catboost,
+}
+
+
+def train_model(args: argparse.Namespace) -> dict[str, float]:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    data_path = Path(args.data_path)
+    df = _load_dataset(data_path)
+    if args.target_column not in df.columns:
+        raise KeyError(f"Target column {args.target_column!r} not present in dataset")
+
+    drop_columns = set(args.drop_columns or [])
+    train_df, val_df = _train_validation_split(df, args.validation_fraction, args.random_state)
+    train_features = _prepare_features(train_df, args.target_column, drop_columns)
+    val_features = _prepare_features(val_df, args.target_column, drop_columns)
+
+    trainer = MODEL_TRAINERS.get(args.model_type)
+    if trainer is None:
+        raise ValueError(f"Unsupported model type: {args.model_type}")
+
+    model, train_pred, val_pred, feature_importances = trainer(
+        train_features,
+        train_df[args.target_column],
+        val_features,
+        val_df[args.target_column],
+        args,
+    )
+
+    train_metrics = regression_metrics(train_df[args.target_column], train_pred)
+    val_metrics = regression_metrics(val_df[args.target_column], val_pred)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics = {"train": train_metrics, "validation": val_metrics}
+
+    with RunLogger(args.experiment_name, args.run_name) as run:
+        run.log_params(
+            {
+                "model_type": args.model_type,
+                "learning_rate": args.learning_rate,
+                "num_boost_round": args.num_boost_round,
+                "num_leaves": args.num_leaves,
+                "max_depth": args.max_depth,
+                "min_data_in_leaf": args.min_data_in_leaf,
+                "feature_fraction": args.feature_fraction,
+                "bagging_fraction": args.bagging_fraction,
+                "lambda_l2": args.lambda_l2,
+            }
+        )
+        run.log_metrics({f"train_{k}": v for k, v in train_metrics.items()})
+        run.log_metrics({f"validation_{k}": v for k, v in val_metrics.items()})
+
+        feature_path = output_dir / f"{args.model_type}_feature_importances.csv"
+        feature_importances.to_csv(feature_path, index=False)
+        run.log_artifact(feature_path)
+
+        preds_path = output_dir / f"{args.model_type}_validation_predictions.csv"
+        pd.DataFrame(
+            {
+                "prediction": val_pred,
+                "label": val_df[args.target_column].to_numpy(),
+            }
+        ).to_csv(preds_path, index=False)
+        run.log_artifact(preds_path)
+
+        metrics_path = output_dir / f"{args.model_type}_metrics.json"
+        metrics_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+        run.log_artifact(metrics_path)
+
+    model_path = output_dir / f"{args.model_type}_model"
+    try:
+        if hasattr(model, "save_model"):
+            model.save_model(str(model_path))  # type: ignore[attr-defined]
+        elif hasattr(model, "save_model_to_file"):
+            model.save_model_to_file(str(model_path))
+    except Exception as exc:  # pragma: no cover
+        LOGGER.warning("Failed to persist model artifact: %s", exc)
+
+    return val_metrics
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train regression baseline")
+    parser.add_argument("--data-path", type=str, default="train_samples_reg")
+    parser.add_argument("--output-dir", type=str, default="artifacts/reg")
+    parser.add_argument("--experiment-name", type=str, default="regression-baseline")
+    parser.add_argument("--run-name", type=str, default="run")
+    parser.add_argument("--target-column", type=str, default="target")
+    parser.add_argument("--drop-columns", nargs="*", default=None)
+    parser.add_argument("--validation-fraction", type=float, default=0.2)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--model-type", type=str, default="lightgbm", choices=list(MODEL_TRAINERS.keys()))
+    parser.add_argument("--learning-rate", type=float, default=0.05)
+    parser.add_argument("--num-boost-round", type=int, default=500)
+    parser.add_argument("--early-stopping-rounds", type=int, default=50)
+    parser.add_argument("--verbose-eval", type=int, default=50)
+    parser.add_argument("--num-leaves", type=int, default=63)
+    parser.add_argument("--max-depth", type=int, default=6)
+    parser.add_argument("--min-data-in-leaf", type=int, default=20)
+    parser.add_argument("--feature-fraction", type=float, default=0.8)
+    parser.add_argument("--bagging-fraction", type=float, default=0.8)
+    parser.add_argument("--lambda-l2", type=float, default=1.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    val_metrics = train_model(args)
+    LOGGER.info("Validation metrics: %s", val_metrics)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/training/tune_rank.py
+++ b/training/tune_rank.py
@@ -1,0 +1,199 @@
+"""Hyper-parameter tuning for the LambdaRank model using Optuna."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+from training.eval_metrics import compute_ranking_metrics
+from training.run_logger import RunLogger
+from training.train_rank import _detect_group_column, _detect_label_column, _load_rank_data, _prepare_features
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _group_kfold_split(groups: Sequence, n_splits: int) -> Iterable[tuple[np.ndarray, np.ndarray]]:
+    unique_groups = np.array(list(dict.fromkeys(groups)))
+    if n_splits < 2:
+        raise ValueError("n_splits must be at least 2")
+    if unique_groups.size < n_splits:
+        raise ValueError("Not enough groups to perform requested splits")
+    fold_sizes = np.full(n_splits, unique_groups.size // n_splits, dtype=int)
+    fold_sizes[: unique_groups.size % n_splits] += 1
+    current = 0
+    group_to_indices: dict[object, np.ndarray] = {}
+    groups_np = np.asarray(groups)
+    for group in unique_groups:
+        group_to_indices[group] = np.where(groups_np == group)[0]
+
+    for fold_size in fold_sizes:
+        start, stop = current, current + fold_size
+        val_groups = unique_groups[start:stop]
+        val_indices = np.concatenate([group_to_indices[group] for group in val_groups])
+        train_groups = np.concatenate([unique_groups[:start], unique_groups[stop:]])
+        train_indices = np.concatenate([group_to_indices[group] for group in train_groups])
+        yield train_indices, val_indices
+        current = stop
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Optuna tuning for LambdaRank")
+    parser.add_argument("--data-path", type=str, default="train_samples_rank")
+    parser.add_argument("--output-dir", type=str, default="artifacts/rank_tuning")
+    parser.add_argument("--experiment-name", type=str, default="rank-tuning")
+    parser.add_argument("--run-name", type=str, default="tuning")
+    parser.add_argument("--group-column", type=str, default=None)
+    parser.add_argument("--label-column", type=str, default=None)
+    parser.add_argument("--drop-columns", nargs="*", default=None)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--n-splits", type=int, default=3)
+    parser.add_argument("--n-trials", type=int, default=50)
+    parser.add_argument("--timeout", type=int, default=None)
+    return parser.parse_args(argv)
+
+
+def _build_dataset(features: pd.DataFrame, labels: pd.Series, groups: pd.Series):
+    try:
+        import lightgbm as lgb
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("LightGBM must be installed for tuning") from exc
+
+    from training.train_rank import _group_sizes
+
+    dataset = lgb.Dataset(features, label=labels, group=_group_sizes(groups.to_numpy()))
+    return dataset
+
+
+def tune_model(args: argparse.Namespace) -> dict[str, float]:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    data_path = Path(args.data_path)
+    df = _load_rank_data(data_path)
+    group_col = _detect_group_column(df, args.group_column)
+    label_col = _detect_label_column(df, args.label_column)
+    df = df.sort_values(group_col).reset_index(drop=True)
+
+    drop_columns = set(args.drop_columns or [])
+    features = _prepare_features(df, label_col, group_col, drop_columns)
+    labels = df[label_col]
+    groups = df[group_col]
+
+    try:
+        import optuna
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("Optuna is required for tuning") from exc
+
+    try:
+        import lightgbm as lgb
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("LightGBM must be installed for tuning") from exc
+
+    rng = np.random.default_rng(args.random_state)
+    unique_groups = groups.drop_duplicates().to_numpy()
+    shuffled_groups = unique_groups.copy()
+    rng.shuffle(shuffled_groups)
+    groups_mapping = {group: idx for idx, group in enumerate(shuffled_groups)}
+    remapped_groups = groups.map(groups_mapping)
+
+    def objective(trial: optuna.Trial) -> float:
+        params = {
+            "objective": "lambdarank",
+            "metric": "ndcg",
+            "ndcg_at": [5, 10, 20],
+            "learning_rate": trial.suggest_float("learning_rate", 0.01, 0.2, log=True),
+            "num_leaves": trial.suggest_int("num_leaves", 16, 255),
+            "min_data_in_leaf": trial.suggest_int("min_data_in_leaf", 10, 100),
+            "feature_fraction": trial.suggest_float("feature_fraction", 0.5, 1.0),
+            "bagging_fraction": trial.suggest_float("bagging_fraction", 0.5, 1.0),
+            "bagging_freq": trial.suggest_int("bagging_freq", 1, 10),
+            "lambda_l2": trial.suggest_float("lambda_l2", 1e-3, 10.0, log=True),
+            "random_state": args.random_state,
+            "verbose": -1,
+        }
+
+        scores: list[float] = []
+        for fold, (train_idx, val_idx) in enumerate(_group_kfold_split(remapped_groups.to_numpy(), args.n_splits)):
+            train_features = features.iloc[train_idx]
+            val_features = features.iloc[val_idx]
+            train_labels = labels.iloc[train_idx]
+            val_labels = labels.iloc[val_idx]
+            train_groups = remapped_groups.iloc[train_idx]
+            val_groups = remapped_groups.iloc[val_idx]
+
+            train_dataset = _build_dataset(train_features, train_labels, train_groups)
+            val_dataset = _build_dataset(val_features, val_labels, val_groups)
+
+            booster = lgb.train(
+                params,
+                train_set=train_dataset,
+                valid_sets=[val_dataset],
+                valid_names=[f"fold{fold}"],
+                num_boost_round=1000,
+                early_stopping_rounds=50,
+                verbose_eval=False,
+            )
+
+            preds = booster.predict(val_features, num_iteration=booster.best_iteration or 1000)
+            metrics = compute_ranking_metrics(val_labels, preds, val_groups, ks=(20,))
+            scores.append(metrics["ndcg@20"])
+
+        return float(np.mean(scores))
+
+    sampler = optuna.samplers.TPESampler(seed=args.random_state)
+    study = optuna.create_study(direction="maximize", sampler=sampler)
+    study.optimize(objective, n_trials=args.n_trials, timeout=args.timeout)
+
+    best_params = study.best_params
+    best_params.update(
+        {
+            "objective": "lambdarank",
+            "metric": "ndcg",
+            "ndcg_at": [5, 10, 20],
+            "random_state": args.random_state,
+        }
+    )
+
+    metrics = {"best_value": study.best_value, "trials": len(study.trials)}
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    params_path = output_dir / "best_params.json"
+    params_path.write_text(json.dumps(best_params, indent=2), encoding="utf-8")
+    metrics_path = output_dir / "study_metrics.json"
+    metrics_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+
+    with RunLogger(args.experiment_name, args.run_name) as run:
+        run.log_params(best_params)
+        run.log_metrics(metrics)
+        run.log_artifact(params_path)
+        run.log_artifact(metrics_path)
+
+        if study.best_trial:
+            trials_summary = [
+                {
+                    "number": trial.number,
+                    "value": trial.value,
+                    "params": trial.params,
+                }
+                for trial in study.trials
+            ]
+            run.log_text(json.dumps(trials_summary, indent=2), "trials.json")
+
+    return metrics
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    metrics = tune_model(args)
+    LOGGER.info("Best tuning metrics: %s", metrics)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+


### PR DESCRIPTION
## Summary
- add a shared evaluation metrics helper and a run logger that falls back to filesystem tracking when MLflow is unavailable
- implement a LightGBM LambdaRank training pipeline with feature importance and SHAP exports, plus an Optuna-based hyper-parameter tuner
- provide binary classification and regression baseline trainers supporting LightGBM, XGBoost and CatBoost with common metrics reporting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e15ea4bbac832d903b180c13fee5fd