### PR TITLE
Add reporting dashboards, weekly reporting workflow, and alerting

### DIFF
--- a/reporting/alerts.py
+++ b/reporting/alerts.py
@@ -1,0 +1,296 @@
+"""Operational alerting for reporting pipelines."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from email.message import EmailMessage
+from typing import Callable, Iterable, Protocol, Sequence
+
+import pandas as pd
+import requests
+
+from utils.backoff import RetryPolicy, retryable, sleep_with_backoff
+from utils.logging import get_logger
+
+
+LOGGER = get_logger(__name__)
+
+
+class SMTPClient(Protocol):
+    """Minimal interface for SMTP interactions."""
+
+    def send_message(self, message: EmailMessage) -> None:  # noqa: D401
+        ...
+
+    def quit(self) -> None:  # noqa: D401
+        ...
+
+
+@dataclass(slots=True)
+class AlertConfig:
+    """Configuration for alert thresholds and notification channels."""
+
+    data_quality_threshold: float = 0.97
+    performance_threshold: float = 0.75
+    drift_threshold: float = 0.2
+    sla_threshold_minutes: int = 90
+    email_sender: str | None = None
+    email_recipients: Sequence[str] = field(default_factory=list)
+    wecom_webhook: str | None = None
+    dingtalk_webhook: str | None = None
+    retry_policy: RetryPolicy = field(
+        default_factory=lambda: RetryPolicy(
+            max_attempts=3,
+            base_delay_ms=500,
+            jitter_ms=250,
+            max_delay_ms=4000,
+        )
+    )
+
+
+@dataclass(slots=True)
+class AlertResult:
+    """Represents a single alert finding."""
+
+    category: str
+    severity: str
+    message: str
+    details: dict[str, float | str]
+
+
+class AlertEvaluator:
+    """Encapsulates metric checks for operational monitoring."""
+
+    def __init__(self, config: AlertConfig) -> None:
+        self._config = config
+
+    def evaluate_data_quality(self, frame: pd.DataFrame, dataset_name: str) -> list[AlertResult]:
+        if frame.empty:
+            return []
+        missing_ratio = frame.isna().mean().mean()
+        LOGGER.debug("Data quality missing ratio for %s: %.4f", dataset_name, missing_ratio)
+        if missing_ratio <= 1 - self._config.data_quality_threshold:
+            return []
+        return [
+            AlertResult(
+                category="data_quality",
+                severity="high",
+                message=f"{dataset_name} missing ratio {missing_ratio:.2%} exceeds threshold",
+                details={"missing_ratio": float(missing_ratio)},
+            )
+        ]
+
+    def evaluate_performance(
+        self,
+        predictions: pd.DataFrame,
+        actuals: pd.DataFrame,
+        *,
+        join_keys: Iterable[str] = ("asin", "site", "snapshot_date"),
+    ) -> list[AlertResult]:
+        if predictions.empty or actuals.empty:
+            return []
+        merged = predictions.merge(actuals, on=list(join_keys), suffixes=("_pred", "_act"))
+        if merged.empty:
+            return []
+        if "predicted_revenue" not in merged or "actual_revenue" not in merged:
+            return []
+        actual = merged["actual_revenue"].astype(float)
+        predicted = merged["predicted_revenue"].astype(float)
+        denom = actual.replace(0, pd.NA).abs()
+        mape = (predicted.subtract(actual).abs() / denom).dropna().mean()
+        accuracy = 1 - mape if pd.notna(mape) else 1.0
+        LOGGER.debug("Model accuracy computed as %.4f", accuracy)
+        if accuracy >= self._config.performance_threshold:
+            return []
+        return [
+            AlertResult(
+                category="performance",
+                severity="high",
+                message=f"Model accuracy dropped to {accuracy:.2%}",
+                details={"accuracy": float(accuracy)},
+            )
+        ]
+
+    def evaluate_feature_drift(
+        self,
+        current: pd.DataFrame,
+        baseline: pd.DataFrame,
+        *,
+        numeric_columns: Iterable[str] | None = None,
+    ) -> list[AlertResult]:
+        if current.empty or baseline.empty:
+            return []
+        numeric_columns = list(numeric_columns or current.select_dtypes("number").columns)
+        if not numeric_columns:
+            return []
+        drifts: list[AlertResult] = []
+        for column in numeric_columns:
+            current_mean = current[column].astype(float).mean()
+            baseline_mean = baseline[column].astype(float).mean()
+            denominator = abs(baseline_mean) if baseline_mean else 1.0
+            drift_score = abs(current_mean - baseline_mean) / denominator
+            LOGGER.debug(
+                "Drift score for %s: %.4f (current=%.4f baseline=%.4f)",
+                column,
+                drift_score,
+                current_mean,
+                baseline_mean,
+            )
+            if drift_score >= self._config.drift_threshold:
+                drifts.append(
+                    AlertResult(
+                        category="drift",
+                        severity="medium",
+                        message=f"Feature {column} drift score {drift_score:.2f} exceeds threshold",
+                        details={"feature": column, "drift_score": float(drift_score)},
+                    )
+                )
+        return drifts
+
+    def evaluate_sla(self, events: pd.DataFrame) -> list[AlertResult]:
+        if events.empty:
+            return []
+        required_columns = {"scheduled_at", "completed_at", "pipeline"}
+        if not required_columns.issubset(events.columns):
+            return []
+        events = events.copy()
+        events["scheduled_at"] = pd.to_datetime(events["scheduled_at"])
+        events["completed_at"] = pd.to_datetime(events["completed_at"])
+        events["delay_minutes"] = (events["completed_at"] - events["scheduled_at"]).dt.total_seconds() / 60
+        breaches = events[events["delay_minutes"] > self._config.sla_threshold_minutes]
+        LOGGER.debug("Found %s SLA breaches", len(breaches))
+        if breaches.empty:
+            return []
+        return [
+            AlertResult(
+                category="sla",
+                severity="high",
+                message="SLA breach detected",
+                details={
+                    "pipeline": row.pipeline,
+                    "delay_minutes": float(row.delay_minutes),
+                },
+            )
+            for row in breaches.itertuples()
+        ]
+
+
+class NotificationService:
+    """Send alerts through configured channels."""
+
+    def __init__(
+        self,
+        config: AlertConfig,
+        smtp_factory: Callable[[], SMTPClient] | None = None,
+    ) -> None:
+        self._config = config
+        self._smtp_factory = smtp_factory
+
+    def _build_email(self, alerts: Sequence[AlertResult]) -> EmailMessage:
+        message = EmailMessage()
+        message["From"] = self._config.email_sender
+        message["To"] = ", ".join(self._config.email_recipients)
+        message["Subject"] = "Reporting alert notification"
+        lines = ["The following alerts were triggered:"]
+        for alert in alerts:
+            lines.append(f"- [{alert.severity.upper()}] {alert.category}: {alert.message}")
+        message.set_content("\n".join(lines))
+        return message
+
+    def send_email(self, alerts: Sequence[AlertResult]) -> None:
+        if not self._config.email_sender or not self._config.email_recipients:
+            LOGGER.debug("Email channel not configured; skipping")
+            return
+        if self._smtp_factory is None:
+            raise ValueError("smtp_factory is required when email is enabled")
+        client = self._smtp_factory()
+        try:
+            client.send_message(self._build_email(alerts))
+        finally:
+            client.quit()
+
+    @retryable(retry_policy=RetryPolicy(max_attempts=3, base_delay_ms=250, jitter_ms=100, max_delay_ms=2000))
+    def send_wecom(self, payload: dict[str, object]) -> None:
+        if not self._config.wecom_webhook:
+            LOGGER.debug("WeCom webhook not configured; skipping")
+            return
+        response = requests.post(self._config.wecom_webhook, json=payload, timeout=5)
+        response.raise_for_status()
+
+    @retryable(retry_policy=RetryPolicy(max_attempts=3, base_delay_ms=250, jitter_ms=100, max_delay_ms=2000))
+    def send_dingtalk(self, payload: dict[str, object]) -> None:
+        if not self._config.dingtalk_webhook:
+            LOGGER.debug("DingTalk webhook not configured; skipping")
+            return
+        response = requests.post(self._config.dingtalk_webhook, json=payload, timeout=5)
+        response.raise_for_status()
+
+
+class AlertManager:
+    """Coordinates evaluation and notification of alerts."""
+
+    def __init__(
+        self,
+        config: AlertConfig,
+        smtp_factory: Callable[[], SMTPClient] | None = None,
+    ) -> None:
+        self._config = config
+        self._evaluator = AlertEvaluator(config)
+        self._notifications = NotificationService(config, smtp_factory=smtp_factory)
+
+    def run(
+        self,
+        *,
+        quality_frame: pd.DataFrame,
+        predictions: pd.DataFrame,
+        actuals: pd.DataFrame,
+        feature_current: pd.DataFrame,
+        feature_baseline: pd.DataFrame,
+        sla_events: pd.DataFrame,
+    ) -> list[AlertResult]:
+        alerts: list[AlertResult] = []
+        alerts.extend(self._evaluator.evaluate_data_quality(quality_frame, "predictions_daily"))
+        alerts.extend(self._evaluator.evaluate_performance(predictions, actuals))
+        alerts.extend(
+            self._evaluator.evaluate_feature_drift(
+                feature_current,
+                feature_baseline,
+            )
+        )
+        alerts.extend(self._evaluator.evaluate_sla(sla_events))
+        if not alerts:
+            LOGGER.info("No alerts triggered during this evaluation")
+            return []
+        LOGGER.warning("Triggering %s alerts", len(alerts))
+        self._notify(alerts)
+        return alerts
+
+    def _notify(self, alerts: Sequence[AlertResult]) -> None:
+        retry_policy = self._config.retry_policy
+        payload = {
+            "msgtype": "text",
+            "text": {
+                "content": "\n".join(
+                    f"[{alert.severity.upper()}] {alert.category}: {alert.message}" for alert in alerts
+                )
+            },
+        }
+        for attempt in range(retry_policy.max_attempts):
+            try:
+                self._notifications.send_email(alerts)
+                self._notifications.send_wecom(payload)
+                self._notifications.send_dingtalk(payload)
+                return
+            except Exception:  # noqa: BLE001
+                LOGGER.exception("Notification attempt %s failed", attempt + 1)
+                if attempt >= retry_policy.max_attempts - 1:
+                    raise
+                sleep_with_backoff(attempt, retry_policy)
+
+
+__all__ = [
+    "AlertConfig",
+    "AlertEvaluator",
+    "AlertManager",
+    "AlertResult",
+    "SMTPClient",
+]

--- a/reporting/dashboard_queries.sql
+++ b/reporting/dashboard_queries.sql
@@ -1,0 +1,120 @@
+-- Canonical Business Intelligence views for weekly dashboards.
+--
+-- vw_top_candidates_daily:
+--   Exposes the daily top predicted ASINs alongside confidence and velocity
+--   metrics used by merchandising and marketing stakeholders.
+-- vw_features_latest:
+--   Provides the most recent feature vector for each ASIN/site pair.
+-- pred_rank_daily:
+--   Supplies row level ranks for daily predictions to support percentile based
+--   slicing in downstream dashboards.
+--
+-- Usage notes:
+--   * These views are designed to run on the analytic replica. They rely on
+--     the tables populated by the scoring pipelines: ``predictions_daily``,
+--     ``category_snapshot_daily`` and ``feature_history``.
+--   * Refresh cadence is daily; consumers should filter by ``snapshot_date``
+--     to restrict the data range.
+--   * All joins are performed on ``asin`` and ``site`` ensuring that ASINs
+--     remain unique per marketplace.
+--   * Additional filters (category, vendor, family) can be applied by
+--     downstream consumers without additional indexes.
+--
+-- Example:
+--   SELECT *
+--   FROM vw_top_candidates_daily
+--   WHERE snapshot_date = DATE('now', '-1 day')
+--   ORDER BY quality_rank
+--   LIMIT 100;
+
+DROP VIEW IF EXISTS vw_top_candidates_daily;
+CREATE VIEW vw_top_candidates_daily AS
+WITH ranked AS (
+    SELECT
+        p.snapshot_date,
+        p.asin,
+        p.site,
+        p.category,
+        p.predicted_revenue,
+        p.predicted_units,
+        p.confidence_score,
+        ROW_NUMBER() OVER (
+            PARTITION BY p.snapshot_date, p.site
+            ORDER BY p.predicted_revenue DESC, p.confidence_score DESC
+        ) AS revenue_rank,
+        ROW_NUMBER() OVER (
+            PARTITION BY p.snapshot_date, p.site
+            ORDER BY p.confidence_score DESC
+        ) AS quality_rank
+    FROM predictions_daily AS p
+)
+SELECT
+    ranked.snapshot_date,
+    ranked.asin,
+    ranked.site,
+    ranked.category,
+    ranked.predicted_revenue,
+    ranked.predicted_units,
+    ranked.confidence_score,
+    ranked.revenue_rank,
+    ranked.quality_rank,
+    c.avg_category_revenue,
+    c.avg_category_units,
+    (ranked.predicted_revenue - c.avg_category_revenue) AS revenue_vs_category,
+    (ranked.predicted_units - c.avg_category_units) AS units_vs_category
+FROM ranked
+LEFT JOIN category_snapshot_daily AS c
+    ON c.snapshot_date = ranked.snapshot_date
+    AND c.category = ranked.category
+WHERE ranked.revenue_rank <= 500;
+
+DROP VIEW IF EXISTS vw_features_latest;
+CREATE VIEW vw_features_latest AS
+WITH latest AS (
+    SELECT
+        f.asin,
+        f.site,
+        f.feature_name,
+        f.feature_value,
+        f.snapshot_ts,
+        ROW_NUMBER() OVER (
+            PARTITION BY f.asin, f.site, f.feature_name
+            ORDER BY f.snapshot_ts DESC
+        ) AS feature_rank
+    FROM feature_history AS f
+)
+SELECT
+    latest.asin,
+    latest.site,
+    latest.feature_name,
+    latest.feature_value,
+    latest.snapshot_ts
+FROM latest
+WHERE latest.feature_rank = 1;
+
+DROP VIEW IF EXISTS pred_rank_daily;
+CREATE VIEW pred_rank_daily AS
+SELECT
+    p.snapshot_date,
+    p.asin,
+    p.site,
+    p.category,
+    p.predicted_revenue,
+    p.predicted_units,
+    PERCENT_RANK() OVER (
+        PARTITION BY p.snapshot_date, p.site
+        ORDER BY p.predicted_revenue
+    ) AS revenue_percentile,
+    PERCENT_RANK() OVER (
+        PARTITION BY p.snapshot_date, p.site
+        ORDER BY p.predicted_units
+    ) AS units_percentile,
+    NTILE(100) OVER (
+        PARTITION BY p.snapshot_date, p.site
+        ORDER BY p.predicted_revenue DESC
+    ) AS revenue_ntile,
+    NTILE(100) OVER (
+        PARTITION BY p.snapshot_date, p.site
+        ORDER BY p.predicted_units DESC
+    ) AS units_ntile
+FROM predictions_daily AS p;

--- a/reporting/dry_run_alerts.py
+++ b/reporting/dry_run_alerts.py
@@ -1,0 +1,90 @@
+"""Dry run helper to execute alert evaluation logic."""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import pandas as pd
+
+from reporting.alerts import AlertConfig, AlertManager
+
+
+class _DummySMTPClient:
+    def send_message(self, message: Any) -> None:  # pragma: no cover - simple stub
+        print("Email message prepared:")
+        print(message)
+
+    def quit(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+def _smtp_factory() -> _DummySMTPClient:
+    return _DummySMTPClient()
+
+
+def build_sample_frames() -> dict[str, pd.DataFrame]:
+    today = dt.date.today()
+    idx = pd.date_range(end=today, periods=7)
+    predictions = pd.DataFrame(
+        {
+            "asin": [f"ASIN{i}" for i in range(len(idx))],
+            "site": ["US"] * len(idx),
+            "snapshot_date": idx,
+            "predicted_revenue": [1000 + i * 10 for i in range(len(idx))],
+            "confidence_score": [0.8] * len(idx),
+        }
+    )
+    actuals = predictions.copy()
+    actuals["actual_revenue"] = predictions["predicted_revenue"] * 0.4
+    features_current = pd.DataFrame(
+        {
+            "feature_a": [0.1, 0.2, 0.3],
+            "feature_b": [1.0, 1.1, 0.9],
+        }
+    )
+    features_baseline = pd.DataFrame(
+        {
+            "feature_a": [0.1, 0.19, 0.28],
+            "feature_b": [1.05, 1.0, 1.02],
+        }
+    )
+    quality_frame = predictions[["asin", "site", "snapshot_date"]].copy()
+    quality_frame["predicted_revenue"] = predictions["predicted_revenue"]
+    quality_frame.loc[0, "predicted_revenue"] = pd.NA
+    sla_events = pd.DataFrame(
+        {
+            "pipeline": ["weekly_report"],
+            "scheduled_at": [dt.datetime.now() - dt.timedelta(minutes=200)],
+            "completed_at": [dt.datetime.now()],
+        }
+    )
+    return {
+        "quality_frame": quality_frame,
+        "predictions": predictions,
+        "actuals": actuals,
+        "feature_current": features_current,
+        "feature_baseline": features_baseline,
+        "sla_events": sla_events,
+    }
+
+
+def main() -> None:
+    frames = build_sample_frames()
+    config = AlertConfig(
+        email_sender="alerts@example.com",
+        email_recipients=["data-team@example.com"],
+        wecom_webhook=None,
+        dingtalk_webhook=None,
+    )
+    manager = AlertManager(config, smtp_factory=_smtp_factory)
+    alerts = manager.run(**frames)
+    if not alerts:
+        print("No alerts triggered in dry run")
+    else:
+        print(f"Triggered {len(alerts)} alerts")
+        for alert in alerts:
+            print(f"- {alert.category}: {alert.message}")
+
+
+if __name__ == "__main__":
+    main()

--- a/reporting/dry_run_dashboard_queries.py
+++ b/reporting/dry_run_dashboard_queries.py
@@ -1,0 +1,143 @@
+"""Dry run helper that validates dashboard SQL against SQLite."""
+from __future__ import annotations
+
+import datetime as dt
+import sqlite3
+from pathlib import Path
+import pandas as pd
+
+SQL_FILE = Path(__file__).with_name("dashboard_queries.sql")
+
+
+def _load_sql() -> str:
+    if not SQL_FILE.exists():
+        raise FileNotFoundError(f"Dashboard SQL file not found: {SQL_FILE}")
+    return SQL_FILE.read_text(encoding="utf-8")
+
+
+def _create_sample_tables(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS predictions_daily (
+            snapshot_date TEXT,
+            asin TEXT,
+            site TEXT,
+            category TEXT,
+            predicted_revenue REAL,
+            predicted_units REAL,
+            confidence_score REAL
+        );
+
+        CREATE TABLE IF NOT EXISTS category_snapshot_daily (
+            snapshot_date TEXT,
+            category TEXT,
+            avg_category_revenue REAL,
+            avg_category_units REAL
+        );
+
+        CREATE TABLE IF NOT EXISTS feature_history (
+            asin TEXT,
+            site TEXT,
+            feature_name TEXT,
+            feature_value REAL,
+            snapshot_ts TEXT
+        );
+        """
+    )
+
+    today = dt.date.today()
+    rows = []
+    for offset in range(0, 7):
+        date_value = today - dt.timedelta(days=offset)
+        for idx in range(1, 6):
+            rows.append(
+                (
+                    date_value.isoformat(),
+                    f"ASIN{idx}",
+                    "US",
+                    "Electronics" if idx % 2 == 0 else "Toys",
+                    1000 + idx * 50 + offset * 10,
+                    20 + idx * 2,
+                    0.8 + idx * 0.01,
+                )
+            )
+    connection.executemany(
+        "INSERT INTO predictions_daily VALUES (?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+
+    category_rows = []
+    for offset in range(0, 14):
+        date_value = today - dt.timedelta(days=offset)
+        category_rows.append(
+            (date_value.isoformat(), "Electronics", 1200 + offset * 5, 25 + offset * 0.5)
+        )
+        category_rows.append(
+            (date_value.isoformat(), "Toys", 900 + offset * 3, 18 + offset * 0.4)
+        )
+    connection.executemany(
+        "INSERT INTO category_snapshot_daily VALUES (?, ?, ?, ?)",
+        category_rows,
+    )
+
+    feature_rows = []
+    for idx in range(1, 4):
+        feature_rows.append(
+            (
+                f"ASIN{idx}",
+                "US",
+                "feature_a",
+                0.1 * idx,
+                (dt.datetime.combine(today, dt.time.min) - dt.timedelta(hours=idx)).isoformat(),
+            )
+        )
+        feature_rows.append(
+            (
+                f"ASIN{idx}",
+                "US",
+                "feature_a",
+                0.1 * idx + 0.05,
+                (dt.datetime.combine(today, dt.time.min) - dt.timedelta(hours=idx - 1)).isoformat(),
+            )
+        )
+    connection.executemany(
+        "INSERT INTO feature_history VALUES (?, ?, ?, ?, ?)",
+        feature_rows,
+    )
+
+
+def execute_dashboard_views(connection: sqlite3.Connection) -> None:
+    """Execute the dashboard SQL script against the provided connection."""
+
+    sql = _load_sql()
+    connection.executescript(sql)
+
+
+def run_dry_run(connection: sqlite3.Connection | None = None) -> dict[str, pd.DataFrame]:
+    """Run the dashboard SQL against a temporary in-memory SQLite database."""
+
+    owned_connection = connection is None
+    connection = connection or sqlite3.connect(":memory:")
+    if owned_connection:
+        connection.row_factory = sqlite3.Row
+    try:
+        _create_sample_tables(connection)
+        execute_dashboard_views(connection)
+        result: dict[str, pd.DataFrame] = {}
+        for view_name in ("vw_top_candidates_daily", "vw_features_latest", "pred_rank_daily"):
+            frame = pd.read_sql_query(f"SELECT * FROM {view_name} LIMIT 5", connection)
+            result[view_name] = frame
+        return result
+    finally:
+        if owned_connection:
+            connection.close()
+
+
+def main() -> None:
+    outputs = run_dry_run()
+    for view_name, frame in outputs.items():
+        print(f"{view_name}: {len(frame)} rows")
+
+
+if __name__ == "__main__":
+    main()

--- a/reporting/weekly_report.py
+++ b/reporting/weekly_report.py
@@ -1,0 +1,582 @@
+"""Weekly merchandising report generation utilities."""
+from __future__ import annotations
+
+import datetime as dt
+import math
+from dataclasses import dataclass, field
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Callable, Mapping, Protocol, Sequence
+from xml.sax.saxutils import escape
+import zipfile
+
+import pandas as pd
+
+from utils.backoff import RetryPolicy, sleep_with_backoff
+from utils.logging import get_logger
+
+
+LOGGER = get_logger(__name__)
+
+
+def _column_letter(index: int) -> str:
+    """Convert a zero-based column index into Excel column letters."""
+
+    result = ""
+    while True:
+        index, remainder = divmod(index, 26)
+        result = chr(ord("A") + remainder) + result
+        if index == 0:
+            break
+        index -= 1
+    return result
+
+
+class SimpleXLSXBuilder:
+    """Create a minimal XLSX workbook without external dependencies."""
+
+    def __init__(self) -> None:
+        self._shared_strings: dict[str, int] = {}
+        self._strings: list[str] = []
+
+    def _string_index(self, value: str) -> int:
+        if value not in self._shared_strings:
+            self._shared_strings[value] = len(self._strings)
+            self._strings.append(value)
+        return self._shared_strings[value]
+
+    @staticmethod
+    def _normalise(value: object) -> object:
+        if isinstance(value, (dt.datetime, dt.date)):
+            return value.isoformat()
+        if pd.isna(value):
+            return None
+        return value
+
+    def _sheet_rows(self, frame: pd.DataFrame) -> list[list[object]]:
+        rows = [list(frame.columns)]
+        for row in frame.itertuples(index=False):
+            rows.append([self._normalise(value) for value in row])
+        return rows
+
+    def _sheet_xml(self, frame: pd.DataFrame) -> bytes:
+        rows = self._sheet_rows(frame)
+        xml_rows: list[str] = []
+        for row_idx, values in enumerate(rows, start=1):
+            cells: list[str] = []
+            for col_idx, value in enumerate(values):
+                ref = f"{_column_letter(col_idx)}{row_idx}"
+                if value is None:
+                    continue
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    if isinstance(value, float) and math.isnan(value):
+                        continue
+                    cell = f'<c r="{ref}" t="n"><v>{value}</v></c>'
+                else:
+                    string_value = escape(str(value))
+                    index = self._string_index(string_value)
+                    cell = f'<c r="{ref}" t="s"><v>{index}</v></c>'
+                cells.append(cell)
+            xml_rows.append(f'<row r="{row_idx}">' + "".join(cells) + "</row>")
+        xml = (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">"
+            "<sheetData>"
+            + "".join(xml_rows)
+            + "</sheetData></worksheet>"
+        )
+        return xml.encode("utf-8")
+
+    def _shared_strings_xml(self) -> bytes:
+        entries = "".join(f'<si><t>{string}</t></si>' for string in self._strings)
+        xml = (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            f"<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"{len(self._strings)}\" uniqueCount=\"{len(self._strings)}\">"
+            + entries
+            + "</sst>"
+        )
+        return xml.encode("utf-8")
+
+    def write(self, path: Path, sheets: dict[str, pd.DataFrame]) -> None:
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr(
+                "[Content_Types].xml",
+                """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+"""
+                + "".join(
+                    f'  <Override PartName="/xl/worksheets/sheet{idx}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>'
+                    for idx in range(1, len(sheets) + 1)
+                )
+                + "\n</Types>",
+            )
+            zf.writestr(
+                "_rels/.rels",
+                """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>""",
+            )
+            zf.writestr(
+                "xl/_rels/workbook.xml.rels",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+                + "".join(
+                    f'<Relationship Id="rId{idx}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet{idx}.xml"/>'
+                    for idx in range(1, len(sheets) + 1)
+                )
+                + "</Relationships>",
+            )
+            zf.writestr(
+                "xl/workbook.xml",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">"
+                "<sheets>"
+                + "".join(
+                    f'<sheet name="{escape(name)}" sheetId="{idx}" r:id="rId{idx}"/>'
+                    for idx, name in enumerate(sheets, start=1)
+                )
+                + "</sheets></workbook>",
+            )
+            zf.writestr(
+                "xl/styles.xml",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><fonts count=\"1\"><font><sz val=\"11\"/><name val=\"Calibri\"/></font></fonts><fills count=\"1\"><fill><patternFill patternType=\"none\"/></fill></fills><borders count=\"1\"><border/></borders><cellStyleXfs count=\"1\"><xf/></cellStyleXfs><cellXfs count=\"1\"><xf xfId=\"0\" applyNumberFormat=\"0\"/></cellXfs><cellStyles count=\"1\"><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\"/></cellStyles></styleSheet>",
+            )
+            for idx, (name, frame) in enumerate(sheets.items(), start=1):
+                zf.writestr(f"xl/worksheets/sheet{idx}.xml", self._sheet_xml(frame))
+            zf.writestr("xl/sharedStrings.xml", self._shared_strings_xml())
+
+
+class SimplePDFBuilder:
+    """Minimal PDF builder that supports simple text tables."""
+
+    def __init__(self) -> None:
+        self._lines: list[str] = []
+
+    @staticmethod
+    def _escape(text: str) -> str:
+        return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+    def add_table(self, title: str, frame: pd.DataFrame, max_rows: int = 40) -> None:
+        self._lines.append(title)
+        if frame.empty:
+            self._lines.append("No data available")
+            self._lines.append("")
+            return
+        header = " | ".join(str(col) for col in frame.columns)
+        self._lines.append(header)
+        preview = frame.head(max_rows)
+        for _, row in preview.iterrows():
+            cells: list[str] = []
+            for value in row:
+                if isinstance(value, (dt.datetime, dt.date)):
+                    cells.append(value.isoformat())
+                elif isinstance(value, float):
+                    cells.append(f"{value:,.2f}")
+                else:
+                    cells.append(str(value))
+            self._lines.append(" | ".join(cells))
+        self._lines.append("")
+
+    def write(self, path: Path) -> None:
+        if not self._lines:
+            self._lines.append("Weekly report")
+        commands = ["BT", "/F1 12 Tf", "14 TL", "72 760 Td"]
+        for index, line in enumerate(self._lines):
+            escaped_line = self._escape(line)
+            if index == 0:
+                commands.append(f"({escaped_line}) Tj")
+            else:
+                commands.extend(["T*", f"({escaped_line}) Tj"])
+        commands.append("ET")
+        content = "\n".join(commands).encode("utf-8")
+        objects: list[bytes] = []
+        objects.append(b"<< /Type /Catalog /Pages 2 0 R >>")
+        objects.append(b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+        objects.append(
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>"
+        )
+        objects.append(b"<< /Length " + str(len(content)).encode("ascii") + b" >>\nstream\n" + content + b"\nendstream")
+        objects.append(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+        with path.open("wb") as handle:
+            handle.write(b"%PDF-1.4\n")
+            offsets = [0]
+            for index, obj in enumerate(objects, start=1):
+                offsets.append(handle.tell())
+                handle.write(f"{index} 0 obj\n".encode("ascii"))
+                handle.write(obj)
+                handle.write(b"\nendobj\n")
+            xref_position = handle.tell()
+            handle.write(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+            handle.write(b"0000000000 65535 f \n")
+            for offset in offsets[1:]:
+                handle.write(f"{offset:010} 00000 n \n".encode("ascii"))
+            handle.write(b"trailer\n")
+            handle.write(f"<< /Size {len(objects) + 1} /Root 1 0 R >>\n".encode("ascii"))
+            handle.write(b"startxref\n")
+            handle.write(f"{xref_position}\n".encode("ascii"))
+            handle.write(b"%%EOF\n")
+
+
+class QueryRunner(Protocol):
+    """Protocol for objects capable of executing SQL queries."""
+
+    def run(self, sql: str, params: Mapping[str, object] | None = None) -> pd.DataFrame:  # noqa: D401
+        ...
+
+
+class ObjectStorageClient(Protocol):
+    """Protocol covering the subset of the S3 client that we require."""
+
+    def upload_file(self, Filename: str, Bucket: str, Key: str) -> None:  # noqa: N803, D401
+        ...
+
+
+class SMTPClient(Protocol):
+    """Minimal interface for SMTP interactions."""
+
+    def send_message(self, message: EmailMessage) -> None:  # noqa: D401
+        ...
+
+    def quit(self) -> None:  # noqa: D401
+        ...
+
+
+@dataclass(slots=True)
+class ScheduleConfig:
+    """Configuration describing when the report should run."""
+
+    weekday: int
+    run_time: dt.time
+    timezone: dt.tzinfo | None = None
+
+
+@dataclass(slots=True)
+class ReportConfig:
+    """Runtime configuration for the weekly report job."""
+
+    output_dir: Path
+    schedule: ScheduleConfig
+    s3_bucket: str | None = None
+    s3_prefix: str = "reports/weekly"
+    email_recipients: Sequence[str] = field(default_factory=list)
+    email_sender: str | None = None
+    email_subject: str = "Weekly Amazon performance report"
+    max_top_candidates: int = 100
+    anomaly_z_threshold: float = 2.5
+    retry_policy: RetryPolicy = field(
+        default_factory=lambda: RetryPolicy(
+            max_attempts=3,
+            base_delay_ms=500,
+            jitter_ms=250,
+            max_delay_ms=4000,
+        )
+    )
+
+
+@dataclass(slots=True)
+class WeeklyReportArtifacts:
+    """Artifacts generated for a single run."""
+
+    report_date: dt.date
+    excel_path: Path
+    pdf_path: Path
+    top_candidates: pd.DataFrame
+    category_deltas: pd.DataFrame
+    anomalies: pd.DataFrame
+
+
+class WeeklyReportGenerator:
+    """Service class that orchestrates data extraction and delivery."""
+
+    def __init__(self, query_runner: QueryRunner, config: ReportConfig) -> None:
+        self._query_runner = query_runner
+        self._config = config
+        self._last_run_at: dt.datetime | None = None
+        self._config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def last_run_at(self) -> dt.datetime | None:
+        return self._last_run_at
+
+    def _fetch_top_candidates(self, report_date: dt.date) -> pd.DataFrame:
+        LOGGER.debug("Fetching top candidates for %s", report_date)
+        sql = """
+        SELECT *
+        FROM vw_top_candidates_daily
+        WHERE snapshot_date BETWEEN :start_date AND :end_date
+        ORDER BY snapshot_date DESC, quality_rank ASC
+        LIMIT :limit
+        """
+        params = {
+            "start_date": report_date - dt.timedelta(days=6),
+            "end_date": report_date,
+            "limit": self._config.max_top_candidates,
+        }
+        frame = self._query_runner.run(sql, params)
+        return frame.reset_index(drop=True)
+
+    def _fetch_category_deltas(self, report_date: dt.date) -> pd.DataFrame:
+        LOGGER.debug("Computing category deltas for %s", report_date)
+        sql = """
+        SELECT snapshot_date, category, SUM(predicted_revenue) AS predicted_revenue
+        FROM vw_top_candidates_daily
+        WHERE snapshot_date BETWEEN :start_date AND :end_date
+        GROUP BY snapshot_date, category
+        """
+        params = {
+            "start_date": report_date - dt.timedelta(days=13),
+            "end_date": report_date,
+        }
+        frame = self._query_runner.run(sql, params)
+        if frame.empty:
+            return frame
+        frame = frame.copy()
+        frame["snapshot_date"] = pd.to_datetime(frame["snapshot_date"]).dt.date
+        pivot = frame.pivot_table(
+            index="category",
+            columns="snapshot_date",
+            values="predicted_revenue",
+            aggfunc="sum",
+        ).sort_index(axis=1)
+        if pivot.shape[1] < 2:
+            pivot["delta"] = 0.0
+            pivot["delta_pct"] = pd.NA
+            return pivot.reset_index()
+        last_col, prev_col = pivot.columns[-1], pivot.columns[-2]
+        pivot["delta"] = pivot[last_col] - pivot[prev_col]
+
+        def _compute_delta_pct(row: pd.Series) -> object:
+            previous_value = row[prev_col]
+            if pd.isna(previous_value) or previous_value == 0:
+                return pd.NA
+            return (row[last_col] - previous_value) / previous_value
+
+        pivot["delta_pct"] = pivot.apply(_compute_delta_pct, axis=1)
+        return pivot.reset_index()
+
+    def _fetch_anomalies(self, report_date: dt.date) -> pd.DataFrame:
+        LOGGER.debug("Detecting anomalies for %s", report_date)
+        sql = """
+        SELECT snapshot_date, site, category, predicted_revenue
+        FROM pred_rank_daily
+        WHERE snapshot_date BETWEEN :start_date AND :end_date
+        """
+        params = {
+            "start_date": report_date - dt.timedelta(days=6),
+            "end_date": report_date,
+        }
+        frame = self._query_runner.run(sql, params)
+        if frame.empty:
+            return frame
+        frame = frame.copy()
+        frame["snapshot_date"] = pd.to_datetime(frame["snapshot_date"])
+        grouped = frame.groupby(["site", "category"], group_keys=False)
+        anomalies = []
+        for (site, category), group in grouped:
+            revenue = group["predicted_revenue"].astype(float)
+            mean = revenue.mean()
+            std = revenue.std(ddof=0)
+            if std == 0:
+                continue
+            z_scores = (revenue - mean) / std
+            mask = z_scores.abs() >= self._config.anomaly_z_threshold
+            if mask.any():
+                outliers = group.loc[mask, ["snapshot_date", "predicted_revenue"]]
+                outliers = outliers.assign(
+                    site=site,
+                    category=category,
+                    z_score=z_scores.loc[mask].round(3),
+                )
+                anomalies.append(outliers)
+        if not anomalies:
+            return pd.DataFrame(
+                columns=["snapshot_date", "predicted_revenue", "site", "category", "z_score"]
+            )
+        result = pd.concat(anomalies, ignore_index=True)
+        result["snapshot_date"] = pd.to_datetime(result["snapshot_date"]).dt.date
+        return result
+
+    def _build_excel_report(
+        self,
+        report_date: dt.date,
+        top_candidates: pd.DataFrame,
+        category_deltas: pd.DataFrame,
+        anomalies: pd.DataFrame,
+    ) -> Path:
+        file_path = self._config.output_dir / f"weekly_report_{report_date.isoformat()}.xlsx"
+        LOGGER.debug("Writing Excel report to %s", file_path)
+        sheets = {
+            "Top 100": top_candidates,
+            "Category Deltas": category_deltas,
+            "Anomalies": anomalies,
+        }
+        builder = SimpleXLSXBuilder()
+        builder.write(file_path, sheets)
+        return file_path
+
+    def _build_pdf_report(
+        self,
+        report_date: dt.date,
+        top_candidates: pd.DataFrame,
+        category_deltas: pd.DataFrame,
+        anomalies: pd.DataFrame,
+    ) -> Path:
+        file_path = self._config.output_dir / f"weekly_report_{report_date.isoformat()}.pdf"
+        LOGGER.debug("Writing PDF report to %s", file_path)
+        pdf = SimplePDFBuilder()
+        pdf.add_table("Top 100 Candidates", top_candidates)
+        pdf.add_table("Category Deltas", category_deltas)
+        pdf.add_table("Anomalies", anomalies)
+        pdf.write(file_path)
+        return file_path
+
+    def generate_report(self, report_date: dt.date | None = None) -> WeeklyReportArtifacts:
+        report_date = report_date or dt.date.today()
+        LOGGER.info("Generating weekly report for %s", report_date)
+        top_candidates = self._fetch_top_candidates(report_date)
+        category_deltas = self._fetch_category_deltas(report_date)
+        anomalies = self._fetch_anomalies(report_date)
+        excel_path = self._build_excel_report(report_date, top_candidates, category_deltas, anomalies)
+        pdf_path = self._build_pdf_report(report_date, top_candidates, category_deltas, anomalies)
+        artifacts = WeeklyReportArtifacts(
+            report_date=report_date,
+            excel_path=excel_path,
+            pdf_path=pdf_path,
+            top_candidates=top_candidates,
+            category_deltas=category_deltas,
+            anomalies=anomalies,
+        )
+        LOGGER.info(
+            "Report generation complete for %s (Excel: %s, PDF: %s)",
+            report_date,
+            excel_path,
+            pdf_path,
+        )
+        scheduled_dt = dt.datetime.combine(report_date, self._config.schedule.run_time)
+        if self._config.schedule.timezone is not None:
+            scheduled_dt = scheduled_dt.replace(tzinfo=self._config.schedule.timezone)
+        self._last_run_at = scheduled_dt
+        return artifacts
+
+    def _deliver_to_s3(self, artifacts: WeeklyReportArtifacts, s3_client: ObjectStorageClient | None) -> None:
+        if not s3_client or not self._config.s3_bucket:
+            LOGGER.debug("Skipping S3 delivery (client or bucket not configured)")
+            return
+        LOGGER.info("Uploading weekly report artifacts to s3://%s/%s", self._config.s3_bucket, self._config.s3_prefix)
+        prefix = self._config.s3_prefix.rstrip("/")
+        for path in (artifacts.excel_path, artifacts.pdf_path):
+            key = f"{prefix}/{path.name}"
+            LOGGER.debug("Uploading %s to %s", path, key)
+            s3_client.upload_file(str(path), Bucket=self._config.s3_bucket, Key=key)
+
+    def _deliver_via_email(
+        self,
+        artifacts: WeeklyReportArtifacts,
+        smtp_factory: Callable[[], SMTPClient] | None,
+    ) -> None:
+        if not self._config.email_recipients or not self._config.email_sender:
+            LOGGER.debug("Skipping email delivery (sender or recipients not configured)")
+            return
+        if smtp_factory is None:
+            raise ValueError("smtp_factory must be provided when email delivery is enabled")
+        LOGGER.info("Sending weekly report email to %s", ", ".join(self._config.email_recipients))
+        message = EmailMessage()
+        message["From"] = self._config.email_sender
+        message["To"] = ", ".join(self._config.email_recipients)
+        message["Subject"] = self._config.email_subject
+        message.set_content(
+            "\n".join(
+                [
+                    f"Weekly report for {artifacts.report_date.isoformat()}",
+                    "Attachments include the Excel workbook and PDF summary.",
+                ]
+            )
+        )
+        attachments = {
+            artifacts.excel_path.name: artifacts.excel_path.read_bytes(),
+            artifacts.pdf_path.name: artifacts.pdf_path.read_bytes(),
+        }
+        for filename, payload in attachments.items():
+            maintype, subtype = ("application", "octet-stream")
+            if filename.endswith(".pdf"):
+                maintype, subtype = "application", "pdf"
+            elif filename.endswith(".xlsx"):
+                maintype, subtype = "application", "vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            message.add_attachment(payload, maintype=maintype, subtype=subtype, filename=filename)
+        client = smtp_factory()
+        try:
+            client.send_message(message)
+        finally:
+            client.quit()
+
+    def deliver_report(
+        self,
+        artifacts: WeeklyReportArtifacts,
+        *,
+        s3_client: ObjectStorageClient | None = None,
+        smtp_factory: Callable[[], SMTPClient] | None = None,
+    ) -> None:
+        retry_policy = self._config.retry_policy
+        for attempt in range(retry_policy.max_attempts):
+            try:
+                self._deliver_to_s3(artifacts, s3_client)
+                self._deliver_via_email(artifacts, smtp_factory)
+                return
+            except Exception:  # noqa: BLE001
+                LOGGER.exception("Delivery attempt %s failed", attempt + 1)
+                if attempt >= retry_policy.max_attempts - 1:
+                    raise
+                sleep_with_backoff(attempt, retry_policy)
+
+    def is_due(self, current_time: dt.datetime | None = None) -> bool:
+        current_time = current_time or dt.datetime.now(tz=self._config.schedule.timezone)
+        scheduled_time = current_time.replace(
+            hour=self._config.schedule.run_time.hour,
+            minute=self._config.schedule.run_time.minute,
+            second=self._config.schedule.run_time.second,
+            microsecond=self._config.schedule.run_time.microsecond,
+        )
+        days_ahead = (self._config.schedule.weekday - scheduled_time.weekday()) % 7
+        scheduled_time = scheduled_time + dt.timedelta(days=days_ahead)
+        if self._last_run_at is None:
+            return current_time >= scheduled_time
+        if current_time < scheduled_time:
+            return False
+        last_run_week = self._last_run_at.isocalendar()[1]
+        current_week = scheduled_time.isocalendar()[1]
+        return current_week != last_run_week or self._last_run_at < scheduled_time
+
+
+def schedule_weekly_report(
+    generator: WeeklyReportGenerator,
+    *,
+    now: dt.datetime | None = None,
+    s3_client: ObjectStorageClient | None = None,
+    smtp_factory: Callable[[], SMTPClient] | None = None,
+) -> WeeklyReportArtifacts | None:
+    """Run the weekly report if the schedule conditions are met."""
+
+    current_time = now or dt.datetime.now(tz=generator._config.schedule.timezone)  # noqa: SLF001
+    if not generator.is_due(current_time):
+        LOGGER.debug("Weekly report not due at %s", current_time)
+        return None
+    artifacts = generator.generate_report(current_time.date())
+    generator.deliver_report(artifacts, s3_client=s3_client, smtp_factory=smtp_factory)
+    return artifacts
+
+
+__all__ = [
+    "ObjectStorageClient",
+    "QueryRunner",
+    "ReportConfig",
+    "ScheduleConfig",
+    "WeeklyReportArtifacts",
+    "WeeklyReportGenerator",
+    "schedule_weekly_report",
+]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from reporting import dry_run_alerts, dry_run_dashboard_queries
+from reporting.alerts import AlertConfig, AlertManager
+from reporting.weekly_report import (
+    ReportConfig,
+    ScheduleConfig,
+    WeeklyReportArtifacts,
+    WeeklyReportGenerator,
+    schedule_weekly_report,
+)
+
+
+class DummyQueryRunner:
+    def __init__(self, frames: dict[str, pd.DataFrame]) -> None:
+        self.frames = frames
+
+    def run(self, sql: str, params: dict[str, object] | None = None) -> pd.DataFrame:
+        if "GROUP BY snapshot_date, category" in sql:
+            return self.frames["category_deltas"].copy()
+        if "FROM pred_rank_daily" in sql:
+            return self.frames["anomalies"].copy()
+        return self.frames["top"].copy()
+
+
+class DummyS3Client:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def upload_file(self, Filename: str, Bucket: str, Key: str) -> None:  # noqa: N803
+        self.calls.append((Filename, Bucket, Key))
+
+
+class DummySMTPClient:
+    def __init__(self) -> None:
+        self.sent_messages: list[Any] = []
+
+    def send_message(self, message: Any) -> None:
+        self.sent_messages.append(message)
+
+    def quit(self) -> None:
+        pass
+
+
+@pytest.fixture()
+def sample_frames() -> dict[str, pd.DataFrame]:
+    dates = pd.date_range("2023-01-01", periods=7)
+    top = pd.DataFrame(
+        {
+            "snapshot_date": dates,
+            "asin": [f"ASIN{i}" for i in range(len(dates))],
+            "site": ["US"] * len(dates),
+            "category": ["Electronics"] * len(dates),
+            "predicted_revenue": [1500 + i * 10 for i in range(len(dates))],
+            "predicted_units": [25 + i for i in range(len(dates))],
+            "confidence_score": [0.85] * len(dates),
+            "revenue_rank": list(range(1, len(dates) + 1)),
+            "quality_rank": list(range(1, len(dates) + 1)),
+        }
+    )
+    category = pd.DataFrame(
+        {
+            "snapshot_date": dates,
+            "category": ["Electronics"] * len(dates),
+            "predicted_revenue": [2000 + i * 5 for i in range(len(dates))],
+        }
+    )
+    anomalies = pd.DataFrame(
+        {
+            "snapshot_date": dates,
+            "site": ["US"] * len(dates),
+            "category": ["Electronics"] * len(dates),
+            "predicted_revenue": [1000, 1020, 1030, 1600, 1040, 1050, 1060],
+        }
+    )
+    return {"top": top, "category_deltas": category, "anomalies": anomalies}
+
+
+def test_dashboard_dry_run_executes_views() -> None:
+    outputs = dry_run_dashboard_queries.run_dry_run()
+    assert set(outputs) == {"vw_top_candidates_daily", "vw_features_latest", "pred_rank_daily"}
+    for frame in outputs.values():
+        assert not frame.empty
+
+
+def test_weekly_report_generation(tmp_path: Path, sample_frames: dict[str, pd.DataFrame]) -> None:
+    schedule = ScheduleConfig(weekday=0, run_time=dt.time(hour=0, minute=0))
+    config = ReportConfig(
+        output_dir=tmp_path,
+        schedule=schedule,
+        s3_bucket="example-bucket",
+        email_recipients=["team@example.com"],
+        email_sender="reports@example.com",
+    )
+    runner = DummyQueryRunner(sample_frames)
+    generator = WeeklyReportGenerator(runner, config)
+    artifacts = generator.generate_report(report_date=dt.date(2023, 1, 7))
+    assert isinstance(artifacts, WeeklyReportArtifacts)
+    assert artifacts.excel_path.exists()
+    assert artifacts.pdf_path.exists()
+    assert len(artifacts.top_candidates) == len(sample_frames["top"])
+
+    s3_client = DummyS3Client()
+    smtp_client = DummySMTPClient()
+    generator.deliver_report(
+        artifacts,
+        s3_client=s3_client,
+        smtp_factory=lambda: smtp_client,
+    )
+    assert len(s3_client.calls) == 2
+    assert len(smtp_client.sent_messages) == 1
+
+
+def test_schedule_weekly_report(tmp_path: Path, sample_frames: dict[str, pd.DataFrame]) -> None:
+    schedule = ScheduleConfig(weekday=0, run_time=dt.time(hour=0, minute=0))
+    config = ReportConfig(output_dir=tmp_path, schedule=schedule)
+    runner = DummyQueryRunner(sample_frames)
+    generator = WeeklyReportGenerator(runner, config)
+    now = dt.datetime(2023, 1, 2, 0, 1)
+    artifacts = schedule_weekly_report(
+        generator,
+        now=now,
+        s3_client=None,
+        smtp_factory=None,
+    )
+    assert artifacts is not None
+    assert generator.last_run_at is not None
+
+    # Subsequent invocation within same week should be skipped
+    artifacts_again = schedule_weekly_report(
+        generator,
+        now=dt.datetime(2023, 1, 2, 1, 0),
+        s3_client=None,
+        smtp_factory=None,
+    )
+    assert artifacts_again is None
+
+
+def test_alert_manager_triggers_notifications(monkeypatch: pytest.MonkeyPatch) -> None:
+    frames = dry_run_alerts.build_sample_frames()
+    config = AlertConfig(
+        email_sender="alerts@example.com",
+        email_recipients=["ops@example.com"],
+        wecom_webhook="https://wecom.test",  # no network thanks to monkeypatch
+        dingtalk_webhook="https://dingtalk.test",
+    )
+    smtp_client = DummySMTPClient()
+    posts: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_post(url: str, json: dict[str, Any], timeout: int) -> Any:
+        posts.append((url, json))
+
+        class _Response:
+            def raise_for_status(self) -> None:
+                return None
+
+        return _Response()
+
+    monkeypatch.setattr("reporting.alerts.requests.post", fake_post)
+    manager = AlertManager(config, smtp_factory=lambda: smtp_client)
+    alerts = manager.run(**frames)
+    assert alerts
+    assert len(smtp_client.sent_messages) == 1
+    assert len(posts) == 2


### PR DESCRIPTION
## Summary
- add canonical BI views for merchandising dashboards along with dry-run validation helpers
- implement a scheduled weekly report generator that produces XLSX/PDF exports and supports S3/email delivery
- introduce alert evaluation covering data quality, performance, drift, and SLA metrics with multi-channel notifications and regression tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e15ea6d634832d914774d03bddfd0e