### PR TITLE
Add batch inference pipeline and schemas

### DIFF
--- a/inference/batch_predict.py
+++ b/inference/batch_predict.py
@@ -1,0 +1,243 @@
+"""Batch scoring utilities for daily inference jobs."""
+from __future__ import annotations
+
+import json
+import textwrap
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import pandas as pd
+
+from inference.schemas import BatchScoreResponse
+from pipelines.score_baseline import score
+from utils.config import load_settings
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ViewSpec:
+    """Configuration for a SQL view export."""
+
+    name: str
+    path: Path
+    artifact: str = "scores"
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path)
+        self.path.mkdir(parents=True, exist_ok=True)
+        self.data_dir = self.path / "daily"
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def sql_path(self) -> Path:
+        return self.path / f"{self.name}.sql"
+
+    def data_path_for(self, run_date: date) -> Path:
+        return self.data_dir / f"{run_date.isoformat()}.csv"
+
+    def persist(self, frame: pd.DataFrame, run_date: date) -> Path:
+        path = self.data_path_for(run_date)
+        frame.to_csv(path, index=False)
+        return path
+
+    def render_view(self, target: Path) -> str:
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        sql = textwrap.dedent(
+            f"""
+            -- Auto-generated on {timestamp}
+            CREATE OR REPLACE VIEW {self.name} AS
+            SELECT *
+            FROM read_csv_auto('{target.as_posix()}');
+            """
+        ).strip()
+        return sql + "\n"
+
+    def write_view(self, target: Path) -> Path:
+        sql_content = self.render_view(target)
+        self.sql_path.write_text(sql_content)
+        return self.sql_path
+
+
+class FeatureRepository:
+    """File-system backed repository for feature snapshots."""
+
+    def __init__(self, base_path: Path):
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def _iter_snapshots(self) -> Iterable[Tuple[date, Path]]:
+        for path in sorted(self.base_path.glob("*")):
+            if not path.is_file():
+                continue
+            stem = path.stem
+            try:
+                snap_date = date.fromisoformat(stem)
+            except ValueError:
+                continue
+            yield snap_date, path
+
+    def load_latest(self, as_of: Optional[date] = None) -> Tuple[pd.DataFrame, Optional[date], Optional[Path]]:
+        candidates: List[Tuple[date, Path]] = list(self._iter_snapshots())
+        if not candidates:
+            return pd.DataFrame(), None, None
+
+        if as_of is not None:
+            candidates = [item for item in candidates if item[0] <= as_of]
+            if not candidates:
+                return pd.DataFrame(), None, None
+
+        snap_date, path = max(candidates, key=lambda item: item[0])
+        frame = self._read_snapshot(path)
+        return frame, snap_date, path
+
+    def _read_snapshot(self, path: Path) -> pd.DataFrame:
+        if path.suffix == ".csv":
+            return pd.read_csv(path, parse_dates=["dt"])
+        if path.suffix == ".json":
+            return pd.read_json(path)
+        raise ValueError(f"Unsupported feature snapshot format: {path.suffix}")
+
+    def persist(self, frame: pd.DataFrame, run_date: date) -> Path:
+        frame_to_write = frame.copy()
+        if "dt" in frame_to_write.columns:
+            frame_to_write["dt"] = pd.to_datetime(frame_to_write["dt"]).dt.strftime("%Y-%m-%d")
+        path = self.base_path / f"{run_date.isoformat()}.csv"
+        frame_to_write.to_csv(path, index=False)
+        return path
+
+
+def _shap_from_reason(reason_str: str) -> Dict[str, float]:
+    try:
+        payload = json.loads(reason_str)
+    except Exception:
+        return {}
+    weights = payload.get("w", {})
+    z_scores = payload.get("z", {})
+    shap_values = {
+        metric: weights.get(metric, 0.0) * z_scores.get(metric, 0.0)
+        for metric in weights
+    }
+    ordered = dict(sorted(shap_values.items(), key=lambda item: abs(item[1]), reverse=True))
+    return ordered
+
+
+def compute_scores(features: pd.DataFrame, settings: Dict, rank_min: int) -> pd.DataFrame:
+    if features.empty:
+        return features
+
+    scored = score(features.copy(), settings, rank_min=rank_min)
+    if scored.empty:
+        return scored
+
+    scored["group_rank"] = (
+        scored.groupby(["site", "category"], dropna=False)["explosive_score"]
+        .rank(method="dense", ascending=False)
+        .astype("Int64")
+    )
+
+    shap_vectors = scored["reason"].apply(_shap_from_reason)
+    scored["_reason_dict"] = shap_vectors
+    scored["reason"] = shap_vectors.apply(json.dumps)
+    if "rank_in_cat" in scored.columns:
+        scored["rank_in_cat"] = scored["rank_in_cat"].astype("Int64")
+    return scored
+
+
+class BatchPredictor:
+    """Coordinates loading features, scoring, and exporting artifacts."""
+
+    def __init__(
+        self,
+        feature_repo: FeatureRepository,
+        score_views: List[ViewSpec],
+        settings: Dict,
+        feature_view: Optional[ViewSpec] = None,
+        model_version: str = "baseline",
+    ) -> None:
+        self.feature_repo = feature_repo
+        self.score_views = score_views
+        self.feature_view = feature_view
+        self.settings = settings
+        self.model_version = model_version
+        self.rank_min = settings.get("scoring", {}).get("rank_min", 20)
+
+    @classmethod
+    def from_settings(
+        cls,
+        settings: Optional[Dict] = None,
+        project_root: Path = Path("."),
+    ) -> "BatchPredictor":
+        settings = settings or load_settings()
+        views_config = settings.get("exports", {}).get("views", [])
+        view_specs: List[ViewSpec] = []
+        feature_view: Optional[ViewSpec] = None
+        for raw in views_config:
+            name = raw["name"]
+            artifact = raw.get("artifact")
+            if artifact is None:
+                artifact = "features" if "feature" in name.lower() else "scores"
+            spec = ViewSpec(name=name, path=project_root / raw["path"], artifact=artifact)
+            if spec.artifact == "features":
+                feature_view = spec
+            else:
+                view_specs.append(spec)
+        if feature_view is None:
+            feature_repo = FeatureRepository(project_root / "exports" / "features" / "daily")
+        else:
+            feature_repo = FeatureRepository(feature_view.data_dir)
+        return cls(
+            feature_repo=feature_repo,
+            score_views=view_specs,
+            settings=settings,
+            feature_view=feature_view,
+            model_version=settings.get("scoring", {}).get("model_version", "baseline"),
+        )
+
+    def run(self, as_of: Optional[date] = None) -> BatchScoreResponse:
+        features, feature_date, _ = self.feature_repo.load_latest(as_of=as_of)
+        if features.empty or feature_date is None:
+            logger.warning("No feature snapshots found for %s", as_of or "latest")
+            run_date = as_of or date.today()
+            return BatchScoreResponse(run_date=run_date, model_version=self.model_version, items=[])
+
+        logger.info("Scoring %s rows for %s", len(features), feature_date.isoformat())
+        scored = compute_scores(features, self.settings, rank_min=self.rank_min)
+        response = BatchScoreResponse.from_dataframe(
+            scored,
+            run_date=feature_date,
+            model_version=self.model_version,
+        )
+
+        feature_path = self.feature_repo.persist(features, feature_date)
+        if self.feature_view is not None:
+            self.feature_view.persist(features, feature_date)
+            self.feature_view.write_view(feature_path)
+
+        if not scored.empty:
+            write_frame = scored.drop(columns=["_reason_dict"], errors="ignore").copy()
+            if "dt" in write_frame.columns:
+                write_frame["dt"] = pd.to_datetime(write_frame["dt"]).dt.strftime("%Y-%m-%d")
+            for view in self.score_views:
+                target = view.persist(write_frame, feature_date)
+                view.write_view(target)
+        else:
+            logger.info("Scored dataframe empty for %s", feature_date.isoformat())
+
+        return response
+
+
+def main() -> None:
+    settings = load_settings()
+    predictor = BatchPredictor.from_settings(settings=settings, project_root=Path("."))
+    result = predictor.run()
+    logger.info(
+        "Completed batch scoring for %s with %d items", result.run_date.isoformat(), len(result.items)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/inference/schemas.py
+++ b/inference/schemas.py
@@ -1,0 +1,185 @@
+"""Lightweight schema utilities shared by batch inference components."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+
+def _ensure_date(value: Any) -> date:
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        return date.fromisoformat(value)
+    raise TypeError(f"Unsupported date value: {value!r}")
+
+
+@dataclass
+class FeatureRecord:
+    """Canonical representation of a feature vector for an ASIN."""
+
+    asin: str
+    site: str
+    dt: date
+    category: Optional[str] = None
+    bsr_trend_30: Optional[float] = None
+    est_sales_30: Optional[float] = None
+    review_vel_14: Optional[float] = None
+    price_vol_30: Optional[float] = None
+    listing_quality: Optional[float] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.dt = _ensure_date(self.dt)
+
+    @classmethod
+    def from_mapping(cls, payload: Dict[str, Any]) -> "FeatureRecord":
+        base_keys = {
+            "asin",
+            "site",
+            "dt",
+            "category",
+            "bsr_trend_30",
+            "est_sales_30",
+            "review_vel_14",
+            "price_vol_30",
+            "listing_quality",
+        }
+        data = {key: payload.get(key) for key in base_keys if key in payload}
+        data.setdefault("asin", payload["asin"])
+        data.setdefault("site", payload["site"])
+        data.setdefault("dt", payload["dt"])
+        data["dt"] = _ensure_date(data["dt"])
+        extras = {k: v for k, v in payload.items() if k not in base_keys}
+        return cls(extra=extras, **data)  # type: ignore[arg-type]
+
+    def to_record(self) -> Dict[str, Any]:
+        record = {
+            "asin": self.asin,
+            "site": self.site,
+            "dt": self.dt,
+            "category": self.category,
+            "bsr_trend_30": self.bsr_trend_30,
+            "est_sales_30": self.est_sales_30,
+            "review_vel_14": self.review_vel_14,
+            "price_vol_30": self.price_vol_30,
+            "listing_quality": self.listing_quality,
+        }
+        record.update(self.extra)
+        return record
+
+
+@dataclass
+class BatchScoreRequest:
+    """Request payload for batch scoring."""
+
+    items: List[FeatureRecord]
+    as_of: Optional[date] = None
+    model_version: str = "baseline"
+    rank_min: int = 20
+
+    def __post_init__(self) -> None:
+        if self.as_of is not None:
+            self.as_of = _ensure_date(self.as_of)
+        if self.rank_min < 1:
+            raise ValueError("rank_min must be positive")
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "BatchScoreRequest":
+        items_payload = payload.get("items", [])
+        items = [FeatureRecord.from_mapping(item) for item in items_payload]
+        as_of = payload.get("as_of")
+        model_version = payload.get("model_version", "baseline")
+        rank_min = payload.get("rank_min", 20)
+        return cls(items=items, as_of=as_of, model_version=model_version, rank_min=rank_min)
+
+    def to_dataframe(self) -> pd.DataFrame:
+        if not self.items:
+            return pd.DataFrame()
+        records = [item.to_record() for item in self.items]
+        frame = pd.DataFrame(records)
+        if "dt" in frame.columns:
+            frame["dt"] = pd.to_datetime(frame["dt"])
+        return frame
+
+
+@dataclass
+class ScoredItem:
+    asin: str
+    site: str
+    dt: date
+    category: Optional[str]
+    explosive_score: float
+    rank_in_cat: Optional[int]
+    group_rank: Optional[int]
+    reason: Dict[str, float]
+
+
+@dataclass
+class BatchScoreResponse:
+    run_date: date
+    model_version: str
+    items: List[ScoredItem]
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        frame: pd.DataFrame,
+        run_date: date,
+        model_version: str,
+    ) -> "BatchScoreResponse":
+        if frame.empty:
+            return cls(run_date=run_date, model_version=model_version, items=[])
+
+        items: List[ScoredItem] = []
+        for _, row in frame.iterrows():
+            reason = row.get("_reason_dict")
+            if not isinstance(reason, dict):
+                reason_field = row.get("reason")
+                if isinstance(reason_field, str):
+                    try:
+                        reason = json.loads(reason_field)
+                    except Exception:  # pragma: no cover
+                        reason = {}
+                elif isinstance(reason_field, dict):
+                    reason = reason_field
+                else:
+                    reason = {}
+
+            rank_in_cat = row.get("rank_in_cat")
+            group_rank = row.get("group_rank")
+            dt_value = row.get("dt")
+            try:
+                parsed_dt = _ensure_date(dt_value)
+            except Exception:  # pragma: no cover - defensive fallback
+                parsed_dt = run_date
+
+            items.append(
+                ScoredItem(
+                    asin=row.get("asin"),
+                    site=row.get("site"),
+                    dt=parsed_dt,
+                    category=row.get("category"),
+                    explosive_score=float(row.get("explosive_score")),
+                    rank_in_cat=int(rank_in_cat) if _is_finite(rank_in_cat) else None,
+                    group_rank=int(group_rank) if _is_finite(group_rank) else None,
+                    reason=reason,
+                )
+            )
+        return cls(run_date=run_date, model_version=model_version, items=items)
+
+
+def _is_finite(value: Any) -> bool:
+    if value is None:
+        return False
+    try:
+        return not pd.isna(value)
+    except Exception:
+        return True
+
+
+import json  # noqa: E402  # isort:skip

--- a/tests/test_inference_batch.py
+++ b/tests/test_inference_batch.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+
+from inference.batch_predict import BatchPredictor, compute_scores
+from inference.schemas import BatchScoreResponse
+from utils.config import load_settings
+
+
+def test_compute_scores_generates_shap():
+    settings = load_settings()
+    frame = pd.DataFrame(
+        {
+            "asin": ["A1", "A2"],
+            "site": ["US", "US"],
+            "dt": ["2024-01-01", "2024-01-01"],
+            "category": ["Home", "Home"],
+            "bsr_trend_30": [0.1, 0.2],
+            "est_sales_30": [200, 150],
+            "review_vel_14": [5, 10],
+            "price_vol_30": [0.05, 0.04],
+            "listing_quality": [0.8, 0.7],
+        }
+    )
+
+    scored = compute_scores(frame, settings, rank_min=10)
+    assert "group_rank" in scored.columns
+    assert scored.loc[0, "_reason_dict"]
+
+
+def test_batch_predictor_exports(tmp_path):
+    project_root = tmp_path
+    settings = load_settings()
+    predictor = BatchPredictor.from_settings(settings=settings, project_root=project_root)
+
+    features_dir = predictor.feature_repo.base_path
+    features_dir.mkdir(parents=True, exist_ok=True)
+    feature_frame = pd.DataFrame(
+        {
+            "asin": ["B1", "B2"],
+            "site": ["US", "US"],
+            "dt": ["2024-02-01", "2024-02-01"],
+            "category": ["Kitchen", "Kitchen"],
+            "bsr_trend_30": [0.4, 0.3],
+            "est_sales_30": [400, 380],
+            "review_vel_14": [15, 12],
+            "price_vol_30": [0.06, 0.07],
+            "listing_quality": [0.9, 0.85],
+        }
+    )
+    (features_dir / "2024-02-01.csv").write_text(feature_frame.to_csv(index=False))
+
+    response = predictor.run(as_of=date(2024, 2, 1))
+    assert isinstance(response, BatchScoreResponse)
+    assert response.items
+    top_item = response.items[0]
+    assert top_item.reason
+
+    for view in predictor.score_views:
+        sql_path = view.sql_path
+        assert sql_path.exists()
+        content = sql_path.read_text()
+        assert view.name in content
+
+    if predictor.feature_view is not None:
+        assert predictor.feature_view.sql_path.exists()


### PR DESCRIPTION
## Summary
- add an inference module that loads feature snapshots, runs the baseline ranker, derives SHAP-style reasons, and writes SQL view artifacts
- define dataclass-based request/response schemas for sharing inference contracts across batch flows
- add unit tests covering score computation helpers and the batch export workflow

## Testing
- pytest tests/test_inference_batch.py

------
https://chatgpt.com/codex/tasks/task_e_68e15ea61ef0832d87417985d403e5a5