### PR TITLE
Implement configurable label pipeline and coverage tests

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -3,22 +3,151 @@ from __future__ import annotations
 import json
 
 import pandas as pd
+import pytest
 
-from training.build_labels import _compute_rank_target, _normalise_for_json
+from training.build_labels import (
+    LabelWindows,
+    Thresholds,
+    build_labels,
+    _normalise_for_json,
+)
 
 
-def test_highest_future_sales_receives_largest_rank() -> None:
-    df = pd.DataFrame(
+def test_empty_windows_returns_empty_tables() -> None:
+    mart_df = pd.DataFrame(
         {
-            "asin": ["A", "A", "A", "B", "B"],
-            "future_sales": [10.0, 20.0, 5.0, 3.0, 7.0],
+            "asin": ["A"],
+            "site": ["US"],
+            "dt": ["2021-01-01"],
+            "sales": [2],
         }
     )
 
-    for asin, group in df.groupby("asin", sort=False):
-        ranked = _compute_rank_target(group)
-        top_row = ranked.loc[group["future_sales"].idxmax()]
-        assert top_row["y_rank"] == ranked["y_rank"].max(), asin
+    result = build_labels(mart_df, windows=LabelWindows(observation_days=3, forecast_days=2))
+
+    assert result.samples.empty
+    assert result.train_samples_bin.empty
+    assert result.train_samples_rank.empty
+    assert result.train_samples_reg.empty
+    assert set(result.reports.keys()) == {
+        "balance",
+        "coverage",
+        "missingness",
+        "mean_encoders",
+        "global_stats",
+    }
+
+
+def test_sparse_sales_coverage_and_targets() -> None:
+    mart_df = pd.DataFrame(
+        {
+            "asin": [
+                "A",
+                "A",
+                "A",
+                "A",
+                "B",
+                "B",
+                "B",
+                "B",
+            ],
+            "site": ["US"] * 8,
+            "dt": [
+                "2021-01-01",
+                "2021-01-03",
+                "2021-01-04",
+                "2021-01-06",
+                "2021-01-01",
+                "2021-01-03",
+                "2021-01-04",
+                "2021-01-06",
+            ],
+            "sales": [5, 7, 4, 8, 0, 0, 0, 0],
+        }
+    )
+
+    result = build_labels(
+        mart_df,
+        windows=LabelWindows(observation_days=3, forecast_days=2),
+        thresholds=Thresholds(r=6, p=0.95, delta=3),
+    )
+
+    samples = result.samples.sort_values(["asin", "t_ref"]).reset_index(drop=True)
+    samples_a = samples[samples["asin"] == "A"].reset_index(drop=True)
+    assert len(samples_a) == 2
+    first, second = samples_a.iloc[0], samples_a.iloc[1]
+
+    assert pytest.approx(first.past_coverage, rel=1e-6) == 2 / 3
+    assert pytest.approx(first.future_coverage, rel=1e-6) == 0.5
+    assert first.future_sales == 4
+    assert first.y_bin == 0
+
+    assert pytest.approx(second.past_coverage, rel=1e-6) == 2 / 3
+    assert pytest.approx(second.future_coverage, rel=1e-6) == 0.5
+    assert second.future_sales == 8
+    assert second.y_bin == 1
+
+    assert set(result.train_samples_reg["asin"]) == set(samples["asin"])
+    assert all(result.train_samples_reg["split"] == "train")
+    assert all(samples["site_mean_y_reg"] == samples["split_mean_y_reg"])
+
+
+def test_percentile_ties_share_rank() -> None:
+    mart_df = pd.DataFrame(
+        {
+            "asin": ["A", "A", "B", "B"],
+            "site": ["US"] * 4,
+            "dt": [
+                "2021-01-01",
+                "2021-01-02",
+                "2021-01-01",
+                "2021-01-02",
+            ],
+            "sales": [1, 5, 2, 5],
+        }
+    )
+
+    result = build_labels(
+        mart_df,
+        windows=LabelWindows(observation_days=1, forecast_days=1),
+        thresholds=Thresholds(r=10, p=0.5, delta=1),
+    )
+
+    samples = result.samples.sort_values(["t_ref", "asin"]).reset_index(drop=True)
+    assert len(samples) == 2
+    assert pytest.approx(samples.loc[0, "y_rank"]) == pytest.approx(samples.loc[1, "y_rank"])
+    assert samples.loc[0, "y_rank"] == pytest.approx(0.75)
+
+
+def test_feature_leakage_guard() -> None:
+    mart_df = pd.DataFrame(
+        {
+            "asin": ["A"] * 3,
+            "site": ["US"] * 3,
+            "dt": ["2021-01-01", "2021-01-02", "2021-01-03"],
+            "sales": [1, 1, 1],
+        }
+    )
+
+    features_df = pd.DataFrame(
+        {
+            "asin": ["A", "A"],
+            "site": ["US", "US"],
+            "dt": ["2021-01-01", "2021-01-03"],
+            "feat": [10, 99],
+        }
+    )
+
+    result = build_labels(
+        mart_df,
+        features_df=features_df,
+        windows=LabelWindows(observation_days=1, forecast_days=1),
+    )
+
+    samples = result.samples.sort_values("t_ref").reset_index(drop=True)
+    assert len(samples) == 2
+    second_features = samples.loc[1, "feature_vector"]
+    assert second_features == {"feat": 10}
 
 
 def test_meta_serialised_as_string_round_trip() -> None:

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,9 +1,21 @@
 """Training utilities for label construction."""
 
 __all__ = [
-    "_compute_rank_target",
+    "LabelWindows",
+    "Thresholds",
+    "SplitConfig",
+    "BuildLabelsResult",
     "_prepare_frame",
+    "_normalise_for_json",
     "build_labels",
 ]
 
-from .build_labels import _compute_rank_target, _prepare_frame, build_labels
+from .build_labels import (
+    BuildLabelsResult,
+    LabelWindows,
+    SplitConfig,
+    Thresholds,
+    _normalise_for_json,
+    _prepare_frame,
+    build_labels,
+)


### PR DESCRIPTION
## Summary
- add a configurable label-building pipeline with rolling sampling, feature joins, target derivation, splits, and diagnostics
- expose the new builder components from the training package for downstream use
- expand the training test suite to cover empty windows, sparse sales, percentile ties, and leakage protection

## Testing
- pytest tests/test_training.py

------
https://chatgpt.com/codex/tasks/task_e_68e15ea3aea0832db34aece38a212d73