### PR TITLE
Fix dataclass slots compatibility in training registry

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import dataclasses
+
+from training import registry
+
+
+def test_dataclass_wrapper_ignores_slots_for_legacy_interpreters(monkeypatch) -> None:
+    real_dataclass = dataclasses.dataclass
+    calls = []
+
+    def fake_dataclass(*args, **kwargs):
+        calls.append(kwargs)
+        if "slots" in kwargs:
+            raise TypeError("dataclass() got an unexpected keyword argument 'slots'")
+        return real_dataclass(*args, **kwargs)
+
+    monkeypatch.setattr(dataclasses, "dataclass", fake_dataclass)
+
+    @registry.dataclass(slots=True)
+    class Dummy:
+        value: int
+
+    instance = Dummy(5)
+    assert instance.value == 5
+    assert dataclasses.is_dataclass(Dummy)
+    assert calls[-1] == {}

--- a/training/registry.py
+++ b/training/registry.py
@@ -1,0 +1,49 @@
+"""Utilities for registering trained models."""
+from __future__ import annotations
+
+import dataclasses
+import sys
+from typing import Any, Dict, Optional
+
+__all__ = ["ModelVersion", "dataclass", "field"]
+
+field = dataclasses.field
+
+_SLOTS_SUPPORTED = sys.version_info >= (3, 10)
+
+
+def _call_dataclass(args: tuple[Any, ...], kwargs: Dict[str, Any]) -> Any:
+    return dataclasses.dataclass(*args, **kwargs)
+
+
+def dataclass(*args: Any, **kwargs: Any) -> Any:
+    """A thin wrapper around :func:`dataclasses.dataclass`.
+
+    The wrapper removes the ``slots`` keyword when the standard library
+    implementation does not support it (Python < 3.10). It also tolerates
+    monkeypatched versions that raise ``TypeError`` when ``slots`` is provided.
+    """
+
+    if "slots" not in kwargs:
+        return _call_dataclass(args, kwargs)
+
+    call_kwargs = dict(kwargs)
+
+    if _SLOTS_SUPPORTED:
+        try:
+            return _call_dataclass(args, call_kwargs)
+        except TypeError as exc:
+            if "slots" not in str(exc):
+                raise
+
+    call_kwargs.pop("slots", None)
+    return _call_dataclass(args, call_kwargs)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelVersion:
+    """Represents a model version stored in the registry."""
+
+    name: str
+    version: str
+    artifact_path: Optional[str] = None


### PR DESCRIPTION
## Summary
- wrap the standard dataclass decorator so slots is ignored on interpreters that do not support it
- re-export the wrapper from training.registry and apply it to ModelVersion
- add a regression test that simulates a pre-3.10 dataclass implementation

## Testing
- pytest tests/test_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68e1672c1c04832d8a1b97a2a2b9a67a