### PR TITLE
Handle dataclass slots keyword on older Python versions

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -27,6 +27,23 @@ def test_dataclass_allows_slots_on_older_interpreters(monkeypatch) -> None:
     assert instance.value == 42
 
 
+def test_dataclass_handles_no_keyword_arguments_message(monkeypatch) -> None:
+    original_dataclass = dataclasses.dataclass
+
+    def fake_dataclass(*args, **kwargs):
+        if kwargs:
+            raise TypeError("dataclass() takes no keyword arguments")
+        return original_dataclass(*args, **kwargs)
+
+    monkeypatch.setattr(dataclasses, "dataclass", fake_dataclass)
+
+    @registry.dataclass(slots=True)
+    class Example:
+        value: int
+
+    assert dataclasses.is_dataclass(Example)
+
+
 def test_dataclass_preserves_other_type_errors(monkeypatch) -> None:
     original_dataclass = dataclasses.dataclass
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 
+import pytest
+
 from training import registry
 
 
@@ -23,3 +25,19 @@ def test_dataclass_allows_slots_on_older_interpreters(monkeypatch) -> None:
 
     assert dataclasses.is_dataclass(Example)
     assert instance.value == 42
+
+
+def test_dataclass_preserves_other_type_errors(monkeypatch) -> None:
+    original_dataclass = dataclasses.dataclass
+
+    def fake_dataclass(*args, **kwargs):
+        if "slots" in kwargs:
+            raise TypeError("slots must be bool")
+        return original_dataclass(*args, **kwargs)
+
+    monkeypatch.setattr(dataclasses, "dataclass", fake_dataclass)
+
+    with pytest.raises(TypeError, match="slots must be bool"):
+        @registry.dataclass(slots=True)
+        class Example:
+            value: int

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import dataclasses
+
+from training import registry
+
+
+def test_dataclass_allows_slots_on_older_interpreters(monkeypatch) -> None:
+    original_dataclass = dataclasses.dataclass
+
+    def fake_dataclass(*args, **kwargs):
+        if "slots" in kwargs:
+            raise TypeError("dataclass() got an unexpected keyword argument 'slots'")
+        return original_dataclass(*args, **kwargs)
+
+    monkeypatch.setattr(dataclasses, "dataclass", fake_dataclass)
+
+    @registry.dataclass(slots=True)
+    class Example:
+        value: int
+
+    instance = Example(42)
+
+    assert dataclasses.is_dataclass(Example)
+    assert instance.value == 42

--- a/training/registry.py
+++ b/training/registry.py
@@ -48,10 +48,10 @@ def dataclass(
             # the unexpected ``slots`` keyword argument.  Only swallow that
             # specific failure; any other TypeError should propagate so the caller
             # is aware of genuine configuration issues.
-            message = str(error)
-            if "slots" not in message:
-                raise
-            if "unexpected keyword argument" not in message:
+            message = (error.args[0] if error.args else str(error)).lower()
+            accepts_no_keywords = "takes no keyword arguments" in message
+            unexpected_slots = "slots" in message and "unexpected keyword argument" in message
+            if not (accepts_no_keywords or unexpected_slots):
                 raise
             return dataclasses.dataclass(cls, **kwargs)
 

--- a/training/registry.py
+++ b/training/registry.py
@@ -1,0 +1,66 @@
+"""Utilities for registering trained models and metadata."""
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Callable, TypeVar, overload
+
+__all__ = ["dataclass", "ModelVersion"]
+
+_T = TypeVar("_T")
+
+
+@overload
+def dataclass(_cls: type[_T], /, **kwargs: Any) -> type[_T]:
+    ...
+
+
+@overload
+def dataclass(
+    _cls: None = ..., /, **kwargs: Any
+) -> Callable[[type[_T]], type[_T]]:  # pragma: no cover - typing overload
+    ...
+
+
+def dataclass(
+    _cls: type[_T] | None = None, /, **kwargs: Any
+) -> type[_T] | Callable[[type[_T]], type[_T]]:
+    """Wrap :func:`dataclasses.dataclass` with backwards compatible ``slots`` support.
+
+    The ``slots`` keyword argument was only introduced in the Python 3.10
+    implementation of :func:`dataclasses.dataclass`.  Some of our callers rely on
+    the ability to request ``slots=True`` regardless of the interpreter version,
+    so this helper swallows the argument on older versions where the standard
+    decorator does not understand it.
+    """
+
+    sentinel = object()
+    slots_value = kwargs.pop("slots", sentinel)
+    kwargs_without_slots = dict(kwargs)
+
+    def _apply(cls: type[_T]) -> type[_T]:
+        if slots_value is sentinel:
+            return dataclasses.dataclass(cls, **kwargs_without_slots)
+
+        try:
+            return dataclasses.dataclass(cls, slots=slots_value, **kwargs_without_slots)
+        except TypeError as error:
+            # On Python < 3.10, ``dataclasses.dataclass`` raises a ``TypeError`` for
+            # the unexpected ``slots`` keyword argument.  Only swallow that
+            # specific failure; any other TypeError should propagate so the caller
+            # is aware of genuine configuration issues.
+            if "slots" not in str(error):
+                raise
+            return dataclasses.dataclass(cls, **kwargs_without_slots)
+
+    if _cls is None:
+        return _apply
+
+    return _apply(_cls)
+
+
+@dataclass
+class ModelVersion:
+    """Metadata describing a registered model version."""
+
+    name: str
+    version: str


### PR DESCRIPTION
## Summary
- add a dataclass wrapper in `training.registry` that tolerates the `slots` argument on older interpreters
- apply the wrapper to `ModelVersion` and re-export it from the module
- cover the regression with a test that simulates a pre-3.10 `dataclasses.dataclass`

## Testing
- pytest tests/test_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68e1d195f360832d9aefda9e532a287e