### PR TITLE
Add LightGBM rank scoring to batch inference

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -55,6 +55,19 @@ features:
     - 30
   min_reviews: 5
 scoring:
+  model_version: "rank-lgbm"
+  model_path: "artifacts/rank/model.txt"
+  price_band_column: "price_band"
+  identifier_columns:
+    - "asin"
+    - "site"
+    - "dt"
+    - "category"
+    - "price_band"
+  group_by_columns:
+    - "site"
+    - "category"
+    - "price_band"
   weights:
     bsr_trend_30: 0.35
     est_sales_30: 0.25

--- a/tests/test_inference_batch.py
+++ b/tests/test_inference_batch.py
@@ -1,22 +1,57 @@
 from __future__ import annotations
 
 from datetime import date
+from pathlib import Path
 
+import numpy as np
 import pandas as pd
+import pytest
 
+from inference import batch_predict
 from inference.batch_predict import BatchPredictor, compute_scores
 from inference.schemas import BatchScoreResponse
 from utils.config import load_settings
 
 
-def test_compute_scores_generates_shap():
-    settings = load_settings()
-    frame = pd.DataFrame(
+class DummyBooster:
+    def __init__(self) -> None:
+        self.best_iteration = 3
+        self._feature_names = [
+            "bsr_trend_30",
+            "est_sales_30",
+            "review_vel_14",
+            "price_vol_30",
+            "listing_quality",
+        ]
+
+    def feature_name(self) -> list[str]:
+        return self._feature_names
+
+    def predict(self, data, num_iteration=None, pred_contrib=False):
+        assert list(data.columns) == self._feature_names
+        base = np.linspace(0.9, 0.5, len(data), dtype=float)
+        if pred_contrib:
+            shap_base = np.array([0.05, 0.04, 0.03, -0.02, 0.01, 0.0])
+            return np.tile(shap_base, (len(data), 1))
+        return base
+
+
+@pytest.fixture(autouse=True)
+def _reset_booster_cache():
+    batch_predict._get_cached_booster.cache_clear()
+    yield
+    batch_predict._get_cached_booster.cache_clear()
+
+
+@pytest.fixture
+def default_frame() -> pd.DataFrame:
+    return pd.DataFrame(
         {
             "asin": ["A1", "A2"],
             "site": ["US", "US"],
             "dt": ["2024-01-01", "2024-01-01"],
             "category": ["Home", "Home"],
+            "price_band": ["20-30", "20-30"],
             "bsr_trend_30": [0.1, 0.2],
             "est_sales_30": [200, 150],
             "review_vel_14": [5, 10],
@@ -25,31 +60,53 @@ def test_compute_scores_generates_shap():
         }
     )
 
-    scored = compute_scores(frame, settings, rank_min=10)
-    assert "group_rank" in scored.columns
-    assert scored.loc[0, "_reason_dict"]
+
+@pytest.fixture
+def default_settings() -> dict:
+    return load_settings()
 
 
-def test_batch_predictor_exports(tmp_path):
+def test_compute_scores_generates_shap(monkeypatch, default_frame, default_settings):
+    monkeypatch.setattr(batch_predict, "_load_rank_booster", lambda path: DummyBooster())
+    scored = compute_scores(default_frame, default_settings, rank_min=10)
+    assert "rank_in_group" in scored.columns
+    top_reason = scored.loc[0, "_reason_dict"]
+    assert isinstance(top_reason, dict)
+    assert len(top_reason) == 5
+    assert "lgbm_score" in scored.columns
+
+
+def test_compute_scores_missing_model(monkeypatch, default_frame, default_settings):
+    def _raise(_):
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(batch_predict, "_load_rank_booster", _raise)
+    scored = compute_scores(default_frame, default_settings, rank_min=10)
+    assert scored.empty
+
+
+def test_compute_scores_missing_columns(monkeypatch, default_frame, default_settings):
+    monkeypatch.setattr(batch_predict, "_load_rank_booster", lambda path: DummyBooster())
+    incomplete = default_frame.drop(columns=["listing_quality"])
+    scored = compute_scores(incomplete, default_settings, rank_min=10)
+    assert scored.empty
+
+
+def test_compute_scores_empty_frame(default_settings):
+    empty = pd.DataFrame()
+    scored = compute_scores(empty, default_settings, rank_min=10)
+    assert scored.empty
+
+
+def test_batch_predictor_exports(tmp_path, monkeypatch, default_frame, default_settings):
+    monkeypatch.setattr(batch_predict, "_load_rank_booster", lambda path: DummyBooster())
     project_root = tmp_path
-    settings = load_settings()
-    predictor = BatchPredictor.from_settings(settings=settings, project_root=project_root)
+    predictor = BatchPredictor.from_settings(settings=default_settings, project_root=project_root)
 
     features_dir = predictor.feature_repo.base_path
     features_dir.mkdir(parents=True, exist_ok=True)
-    feature_frame = pd.DataFrame(
-        {
-            "asin": ["B1", "B2"],
-            "site": ["US", "US"],
-            "dt": ["2024-02-01", "2024-02-01"],
-            "category": ["Kitchen", "Kitchen"],
-            "bsr_trend_30": [0.4, 0.3],
-            "est_sales_30": [400, 380],
-            "review_vel_14": [15, 12],
-            "price_vol_30": [0.06, 0.07],
-            "listing_quality": [0.9, 0.85],
-        }
-    )
+    feature_frame = default_frame.copy()
+    feature_frame["dt"] = ["2024-02-01", "2024-02-01"]
     (features_dir / "2024-02-01.csv").write_text(feature_frame.to_csv(index=False))
 
     response = predictor.run(as_of=date(2024, 2, 1))
@@ -57,6 +114,9 @@ def test_batch_predictor_exports(tmp_path):
     assert response.items
     top_item = response.items[0]
     assert top_item.reason
+    assert response.feature_snapshot_path
+    assert response.score_artifacts
+    assert all(Path(path).exists() for path in response.score_artifacts.values())
 
     for view in predictor.score_views:
         sql_path = view.sql_path

--- a/utils/config.py
+++ b/utils/config.py
@@ -22,6 +22,11 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
     },
     "features": {"rolling": [7, 14, 30]},
     "scoring": {
+        "model_version": "rank-lgbm",
+        "model_path": "artifacts/rank/model.txt",
+        "price_band_column": "price_band",
+        "identifier_columns": ["asin", "site", "dt", "category", "price_band"],
+        "group_by_columns": ["site", "category", "price_band"],
         "weights": {
             "bsr_trend_30": 0.35,
             "est_sales_30": 0.25,


### PR DESCRIPTION
## Summary
- load the trained LambdaRank LightGBM model during batch scoring and compute prediction scores and SHAP-based explanations
- enrich batch scoring exports with group-level rankings, model metadata, and persisted artifact paths
- expand configuration defaults and tests to cover rank-model feature requirements and failure scenarios

## Testing
- pytest tests/test_inference_batch.py

------
https://chatgpt.com/codex/tasks/task_e_68e24136ad70832d840e206fe14e8de2