### PR TITLE
Add AI enhancement layer base scaffolding

### DIFF
--- a/ai/__init__.py
+++ b/ai/__init__.py
@@ -1,0 +1,22 @@
+"""AI enhancement layer public interfaces."""
+
+from .clients.base import EmbeddingClient, LLMClient
+from .models import (
+    ChatGenerationRequest,
+    EmbeddingRequest,
+    EmbeddingResponse,
+    GenerationRequest,
+    GenerationResponse,
+    Message,
+)
+
+__all__ = [
+    "LLMClient",
+    "EmbeddingClient",
+    "GenerationRequest",
+    "GenerationResponse",
+    "ChatGenerationRequest",
+    "EmbeddingRequest",
+    "EmbeddingResponse",
+    "Message",
+]

--- a/ai/clients/__init__.py
+++ b/ai/clients/__init__.py
@@ -1,0 +1,5 @@
+"""Client interfaces for AI providers."""
+
+from .base import EmbeddingClient, LLMClient
+
+__all__ = ["LLMClient", "EmbeddingClient"]

--- a/ai/clients/base.py
+++ b/ai/clients/base.py
@@ -1,0 +1,40 @@
+"""Abstract client definitions for external AI providers."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..models import (
+    ChatGenerationRequest,
+    EmbeddingRequest,
+    EmbeddingResponse,
+    GenerationRequest,
+    GenerationResponse,
+)
+
+
+class LLMClient(ABC):
+    """Base interface for interacting with large language model providers."""
+
+    @abstractmethod
+    def generate(self, request: GenerationRequest) -> GenerationResponse:
+        """Invoke a text completion style model."""
+
+        # TODO(manual): 接入真实供应商 API
+        raise NotImplementedError
+
+    @abstractmethod
+    def chat(self, request: ChatGenerationRequest) -> GenerationResponse:
+        """Invoke a chat completion style model."""
+
+        raise NotImplementedError
+
+
+class EmbeddingClient(ABC):
+    """Base interface for generating vector embeddings."""
+
+    @abstractmethod
+    def embed(self, request: EmbeddingRequest) -> EmbeddingResponse:
+        """Invoke an embedding model and return vector outputs."""
+
+        # TODO(manual): 接入真实供应商 API
+        raise NotImplementedError

--- a/ai/models.py
+++ b/ai/models.py
@@ -1,0 +1,72 @@
+"""Data models for AI enhancement layer."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, List, Mapping, Optional, Sequence
+
+
+@dataclass
+class GenerationRequest:
+    """Parameters for a single LLM generation request."""
+
+    prompt: str
+    model: Optional[str] = None
+    max_tokens: Optional[int] = None
+    temperature: float = 0.7
+    top_p: float = 1.0
+    extra_parameters: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Message:
+    """Represents a single message within a chat-style interaction."""
+
+    role: str
+    content: str
+    name: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GenerationResponse:
+    """Result returned from a language model generation."""
+
+    text: str
+    model: Optional[str] = None
+    usage_tokens: Optional[int] = None
+    finish_reason: Optional[str] = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ChatGenerationRequest:
+    """Parameters for multi-message chat generations."""
+
+    messages: Sequence[Message]
+    model: Optional[str] = None
+    max_tokens: Optional[int] = None
+    temperature: float = 0.7
+    top_p: float = 1.0
+    extra_parameters: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EmbeddingRequest:
+    """Parameters for generating vector embeddings."""
+
+    inputs: Sequence[str]
+    model: Optional[str] = None
+    extra_parameters: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EmbeddingResponse:
+    """Result returned from an embedding model invocation."""
+
+    embeddings: List[List[float]]
+    model: Optional[str] = None
+    usage_tokens: Optional[int] = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    raw: Mapping[str, Any] = field(default_factory=dict)

--- a/ai/pipelines/__init__.py
+++ b/ai/pipelines/__init__.py
@@ -1,0 +1,3 @@
+"""Pipeline primitives for AI workflows."""
+
+__all__ = []


### PR DESCRIPTION
## Summary
- add an `ai` package to host the enhancement layer scaffolding
- provide data models that describe LLM/chat requests and embedding responses
- define abstract LLM and embedding clients with placeholders for vendor integrations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3eabd4788832d84c915df66e2a2b2