### PR TITLE
Add AI comment summarizer and keyword clustering pipelines

### DIFF
--- a/ai/pipelines/__init__.py
+++ b/ai/pipelines/__init__.py
@@ -1,3 +1,6 @@
 """Pipeline primitives for AI workflows."""
 
-__all__ = []
+from .comment_summarizer import generate_comment_summaries
+from .keyword_cluster import cluster_keywords
+
+__all__ = ["generate_comment_summaries", "cluster_keywords"]

--- a/ai/pipelines/comment_summarizer.py
+++ b/ai/pipelines/comment_summarizer.py
@@ -1,0 +1,130 @@
+"""Utilities for summarising customer comments with LLMs."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+from ..clients.base import LLMClient
+from ..models import GenerationRequest, GenerationResponse
+
+
+@dataclass(frozen=True)
+class CommentSummary:
+    """Container for a single batch summary."""
+
+    batch_index: int
+    comments: Sequence[str]
+    prompt: str
+    response: GenerationResponse
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the summary to a JSON-friendly mapping."""
+
+        return {
+            "batch_index": self.batch_index,
+            "comments": list(self.comments),
+            "prompt": self.prompt,
+            "summary": self.response.text.strip(),
+            "model": self.response.model,
+            "raw": self.response.raw,
+        }
+
+
+PROMPT_TEMPLATE = (
+    "You are preparing concise summaries for the customer feedback review.\n"
+    "Summarise the key themes and actionable points from the following comments:\n"
+    "{comments}\n\n"
+    "Format the answer as bullet points grouped by theme."
+)
+
+
+def _batched(items: Sequence[str], batch_size: int) -> Iterable[Sequence[str]]:
+    """Yield batches of ``items`` respecting the requested ``batch_size``."""
+
+    if batch_size <= 0:
+        raise ValueError("batch_size must be a positive integer")
+
+    for start in range(0, len(items), batch_size):
+        yield items[start : start + batch_size]
+
+
+def _build_prompt(comments: Sequence[str]) -> str:
+    """Construct the prompt payload for the provided ``comments``."""
+
+    formatted = "\n".join(f"- {comment}" for comment in comments)
+    return PROMPT_TEMPLATE.format(comments=formatted)
+
+
+def _default_output_dir(root: Path, report_date: date) -> Path:
+    """Resolve the standard reporting directory for a run."""
+
+    return root / report_date.strftime("%Y%m%d") / "ai"
+
+
+def generate_comment_summaries(
+    comments: Sequence[str],
+    *,
+    llm_client: LLMClient,
+    batch_size: int = 10,
+    model: Optional[str] = None,
+    window_start: Optional[datetime] = None,
+    window_end: Optional[datetime] = None,
+    report_date: Optional[date] = None,
+    output_root: Path | str = Path("reports/offline_eval"),
+    extra_parameters: Optional[Mapping[str, Any]] = None,
+) -> Path:
+    """Generate summaries for ``comments`` using the provided ``llm_client``.
+
+    The resulting report is persisted under ``reports/offline_eval/{date}/ai`` and
+    the path to the generated JSON file is returned.
+    """
+
+    # TODO(manual): 设置正式 prompt 模板与安全过滤。
+
+    report_date = report_date or date.today()
+    output_root = Path(output_root)
+    output_dir = _default_output_dir(output_root, report_date)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    extra_parameters = extra_parameters or {}
+    summaries: List[CommentSummary] = []
+
+    for batch_index, chunk in enumerate(_batched(list(comments), batch_size)):
+        if not chunk:
+            continue
+        prompt = _build_prompt(chunk)
+        request = GenerationRequest(
+            prompt=prompt,
+            model=model,
+            extra_parameters=extra_parameters,
+        )
+        response = llm_client.generate(request)
+        summaries.append(
+            CommentSummary(
+                batch_index=batch_index,
+                comments=tuple(chunk),
+                prompt=prompt,
+                response=response,
+            )
+        )
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "model_version": model or (summaries[0].response.model if summaries else None),
+        "window": {
+            "start": window_start.isoformat() if window_start else None,
+            "end": window_end.isoformat() if window_end else None,
+        },
+        "batch_size": batch_size,
+        "summary_count": len(summaries),
+        "summaries": [summary.to_dict() for summary in summaries],
+    }
+
+    output_path = output_dir / "comment_summaries.json"
+    with output_path.open("w", encoding="utf-8") as fp:
+        json.dump(payload, fp, ensure_ascii=False, indent=2)
+
+    return output_path

--- a/ai/pipelines/keyword_cluster.py
+++ b/ai/pipelines/keyword_cluster.py
@@ -1,0 +1,182 @@
+"""Keyword clustering workflow powered by embeddings."""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+import numpy as np
+
+from ..clients.base import EmbeddingClient
+from ..models import EmbeddingRequest
+
+# TODO(manual): 由合规团队维护词表
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "or",
+    "the",
+    "to",
+    "with",
+    "for",
+}
+
+# TODO(manual): 由合规团队维护词表
+_SENSITIVE_WHITELIST = {
+    "amazon",
+    "prime",
+}
+
+
+def _normalise(keyword: str) -> str:
+    return keyword.strip()
+
+
+def _filter_keywords(keywords: Sequence[str]) -> List[str]:
+    """Filter out stop words while respecting the sensitive whitelist."""
+
+    filtered: List[str] = []
+    seen = set()
+    for keyword in keywords:
+        normalised = _normalise(keyword)
+        if not normalised:
+            continue
+        key_lower = normalised.lower()
+        if key_lower not in _SENSITIVE_WHITELIST and key_lower in _STOPWORDS:
+            continue
+        if key_lower in seen:
+            continue
+        seen.add(key_lower)
+        filtered.append(normalised)
+    return filtered
+
+
+def _default_output_dir(root: Path, report_date: date) -> Path:
+    return root / report_date.strftime("%Y%m%d") / "ai"
+
+
+def _initial_centroids(vectors: np.ndarray, k: int, rng: np.random.Generator) -> np.ndarray:
+    indices = rng.choice(len(vectors), size=k, replace=False)
+    return vectors[indices]
+
+
+def _assign_clusters(vectors: np.ndarray, centroids: np.ndarray) -> np.ndarray:
+    distances = np.linalg.norm(vectors[:, None, :] - centroids[None, :, :], axis=2)
+    return np.argmin(distances, axis=1)
+
+
+def _recompute_centroids(vectors: np.ndarray, labels: np.ndarray, k: int) -> np.ndarray:
+    centroids = np.zeros((k, vectors.shape[1]), dtype=vectors.dtype)
+    for idx in range(k):
+        mask = labels == idx
+        if not np.any(mask):
+            continue
+        centroids[idx] = vectors[mask].mean(axis=0)
+    return centroids
+
+
+def _kmeans(vectors: np.ndarray, k: int, *, max_iter: int = 50, seed: int = 42) -> np.ndarray:
+    if k <= 0:
+        raise ValueError("k must be a positive integer")
+    if len(vectors) < k:
+        raise ValueError("Number of vectors must be >= k")
+
+    rng = np.random.default_rng(seed)
+    centroids = _initial_centroids(vectors, k, rng)
+
+    for _ in range(max_iter):
+        labels = _assign_clusters(vectors, centroids)
+        new_centroids = _recompute_centroids(vectors, labels, k)
+        # Handle empty clusters by reinitialising them randomly
+        for idx in range(k):
+            if not np.any(labels == idx):
+                replacement = rng.choice(len(vectors))
+                new_centroids[idx] = vectors[replacement]
+        if np.allclose(new_centroids, centroids):
+            break
+        centroids = new_centroids
+    else:
+        labels = _assign_clusters(vectors, centroids)
+
+    return labels
+
+
+def cluster_keywords(
+    keywords: Sequence[str],
+    *,
+    embedding_client: EmbeddingClient,
+    num_clusters: int = 5,
+    model: Optional[str] = None,
+    window_start: Optional[datetime] = None,
+    window_end: Optional[datetime] = None,
+    report_date: Optional[date] = None,
+    output_root: Path | str = Path("reports/offline_eval"),
+    extra_parameters: Optional[Mapping[str, Any]] = None,
+    random_seed: int = 42,
+) -> Path:
+    """Cluster the provided ``keywords`` using embeddings and persist the result."""
+
+    report_date = report_date or date.today()
+    output_root = Path(output_root)
+    output_dir = _default_output_dir(output_root, report_date)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    filtered_keywords = _filter_keywords(keywords)
+    if not filtered_keywords:
+        raise ValueError("No keywords available for clustering after filtering")
+
+    extra_parameters = extra_parameters or {}
+    request = EmbeddingRequest(
+        inputs=filtered_keywords,
+        model=model,
+        extra_parameters=extra_parameters,
+    )
+    response = embedding_client.embed(request)
+
+    vectors = np.asarray(response.embeddings, dtype=float)
+    if vectors.ndim != 2:
+        raise ValueError("Embeddings must be a 2D array")
+
+    k = min(num_clusters, len(filtered_keywords))
+    labels = _kmeans(vectors, k, seed=random_seed)
+
+    clusters: List[Dict[str, Any]] = []
+    for cluster_index in range(k):
+        members = [
+            {
+                "keyword": filtered_keywords[item_index],
+                "embedding": vectors[item_index].tolist(),
+            }
+            for item_index, label in enumerate(labels)
+            if label == cluster_index
+        ]
+        if not members:
+            continue
+        centroid = np.mean([member["embedding"] for member in members], axis=0).tolist()
+        clusters.append(
+            {
+                "cluster_id": cluster_index,
+                "keywords": members,
+                "centroid": centroid,
+            }
+        )
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "model_version": model or response.model,
+        "window": {
+            "start": window_start.isoformat() if window_start else None,
+            "end": window_end.isoformat() if window_end else None,
+        },
+        "num_clusters": k,
+        "filtered_keyword_count": len(filtered_keywords),
+        "clusters": clusters,
+    }
+
+    output_path = output_dir / "keyword_clusters.json"
+    with output_path.open("w", encoding="utf-8") as fp:
+        json.dump(payload, fp, ensure_ascii=False, indent=2)
+
+    return output_path

--- a/tests/test_ai_pipelines.py
+++ b/tests/test_ai_pipelines.py
@@ -1,0 +1,122 @@
+"""Tests for AI pipeline utilities."""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from pathlib import Path
+
+from ai.models import EmbeddingRequest, EmbeddingResponse, GenerationRequest, GenerationResponse
+from ai.pipelines import cluster_keywords, generate_comment_summaries
+from ai.clients.base import EmbeddingClient, LLMClient
+
+
+class StubLLMClient(LLMClient):
+    """Stub LLM client capturing requests for assertions."""
+
+    def __init__(self) -> None:
+        self.requests: list[GenerationRequest] = []
+
+    def generate(self, request: GenerationRequest) -> GenerationResponse:
+        self.requests.append(request)
+        return GenerationResponse(
+            text=f"summary-{len(self.requests)}",
+            model="stub-llm",
+        )
+
+    def chat(self, request):  # pragma: no cover - not needed for tests
+        raise NotImplementedError
+
+
+class StubEmbeddingClient(EmbeddingClient):
+    """Stub embedding client returning deterministic vectors."""
+
+    def __init__(self, vector_map: dict[str, list[float]]) -> None:
+        self.vector_map = vector_map
+        self.requests: list[EmbeddingRequest] = []
+
+    def embed(self, request: EmbeddingRequest) -> EmbeddingResponse:
+        self.requests.append(request)
+        embeddings = [self.vector_map[item] for item in request.inputs]
+        return EmbeddingResponse(
+            embeddings=embeddings,
+            model="stub-embedding",
+        )
+
+
+def test_generate_comment_summaries(tmp_path: Path) -> None:
+    comments = [
+        "Love the durability of this item.",
+        "Shipping was slower than expected.",
+        "Customer support resolved my issue quickly.",
+    ]
+    client = StubLLMClient()
+
+    output_path = generate_comment_summaries(
+        comments,
+        llm_client=client,
+        batch_size=2,
+        model="stub-llm-v1",
+        window_start=datetime(2023, 1, 1),
+        window_end=datetime(2023, 1, 7, 23, 59),
+        report_date=date(2023, 1, 7),
+        output_root=tmp_path,
+    )
+
+    assert output_path.exists()
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["model_version"] == "stub-llm-v1"
+    assert data["summary_count"] == 2
+    assert len(data["summaries"]) == 2
+
+    prompts = [request.prompt for request in client.requests]
+    assert len(prompts) == 2
+    assert "Love the durability of this item." in prompts[0]
+    assert "Customer support resolved my issue quickly." in "\n".join(prompts)
+
+    expected_dir = tmp_path / "20230107" / "ai"
+    assert output_path.parent == expected_dir
+
+
+def test_cluster_keywords(tmp_path: Path) -> None:
+    keywords = [
+        "Battery life",
+        "and",
+        "Delivery speed",
+        "Prime",
+    ]
+    vector_map = {
+        "Battery life": [0.0, 0.0],
+        "Delivery speed": [10.0, 0.0],
+        "Prime": [0.0, 10.0],
+    }
+    client = StubEmbeddingClient(vector_map)
+
+    output_path = cluster_keywords(
+        keywords,
+        embedding_client=client,
+        num_clusters=2,
+        model="embed-v1",
+        window_start=datetime(2023, 2, 1),
+        window_end=datetime(2023, 2, 7, 23, 59),
+        report_date=date(2023, 2, 7),
+        output_root=tmp_path,
+        random_seed=0,
+    )
+
+    assert output_path.exists()
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["model_version"] == "embed-v1"
+    assert data["num_clusters"] == 2
+
+    captured_inputs = client.requests[0].inputs
+    assert captured_inputs == ["Battery life", "Delivery speed", "Prime"]
+
+    clustered_keywords = sorted(
+        keyword["keyword"]
+        for cluster in data["clusters"]
+        for keyword in cluster["keywords"]
+    )
+    assert clustered_keywords == ["Battery life", "Delivery speed", "Prime"]
+
+    expected_dir = tmp_path / "20230207" / "ai"
+    assert output_path.parent == expected_dir


### PR DESCRIPTION
## Summary
- add a comment summarization pipeline that batches prompts, calls the LLM client, and records outputs under the offline evaluation reports tree
- add a keyword clustering pipeline that filters keywords, calls the embedding client, performs k-means clustering, and writes structured results
- add stub-based unit tests covering both pipelines and expected report structure

## Testing
- pytest tests/test_ai_pipelines.py

------
https://chatgpt.com/codex/tasks/task_e_68e3ebf5ac18832d9f8b069bb8927bef