### PR TITLE
Ensure CI uses Python 3.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies
-        run: 
+        run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Install dependencies
-        run: 
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+
+      - name: Show Python & PyTest versions
+        run: |
+          which python
+          python -V
+          pytest --version
+
       - name: Run tests
         run: pytest -q

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,14 +16,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -35,6 +36,11 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Show Python & PyTest versions
+      run: |
+        which python
+        python -V
+        pytest --version
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
## Summary
- update CI workflows to require Python 3.12 and remove duplicate dependency installation
- add explicit Python version logging steps before running pytest
- refresh the matrix workflow to test only on Python 3.10+

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e40d02dda4832d886480a9a0b28f83