### PR TITLE
Fix CI Python commands and require Python 3.11+

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -23,9 +23,9 @@ jobs:
         cache: 'pip'
     - name: Install dependencies
       run: |
-        python -m python -m python -m pip install --upgrade pip
-        python -m python -m python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then python -m python -m pip install -r requirements.txt; fi
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -36,7 +36,7 @@ jobs:
       run: |
         which python
         python -V
-        python -m python -m pytest --version
+        python -m pytest --version
     - name: Test with pytest
       run: |
         python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ tests/                  # Unit tests for connectors + pipelines
 
 ## Getting Started
 
-1. **Install dependencies**
+1. **Install dependencies** (requires Python 3.11 or newer)
    ```bash
    python -m venv .venv
    source .venv/bin/activate

--- a/README.zh.md
+++ b/README.zh.md
@@ -16,7 +16,7 @@ tests/                  # connectors 与 pipelines 的单测
 
 ## 快速开始
 
-1. **安装依赖**
+1. **安装依赖**（需要 Python 3.11 及以上版本）
    ```bash
    python -m venv .venv
    source .venv/bin/activate


### PR DESCRIPTION
## Summary
- correct the GitHub Actions workflow to use valid `python -m pip` and `python -m pytest` invocations
- update the CI matrix to only target Python 3.11 and 3.12 so the runtime is strictly greater than 3.10
- document the Python 3.11+ requirement in both README files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4b7cbd7b4832daf2a19eeb78f6f53