### PR TITLE
Add provider options for Qwen and Claude in AI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ tests/                  # connectors、pipelines 等单元测试
    ```bash
    cp config/secrets.example.env .env
    ```
+   - `.env` 模板对 Unified Data、数据库、Keepa、SP-API 以及新增的 Qwen/Claude LLM 提供商给出了申请入口，可按照注释中的链接申请访问令牌。
    - `AMAZON_PARTNER_TAG`、`AMAZON_ACCESS_KEY`、`AMAZON_SECRET_KEY`：Amazon API 凭证。
    - `DATABASE_URL`：PostgreSQL 连接串（示例：`postgresql://user:pass@localhost:5432/asin`）。
 2. 核对 `config/settings.yaml`：
    - `ingest.rate_limit` 控制 API 调用频率。
    - `storage.raw_bucket`/`warehouse.schema` 指定数据落地位置。
    - `ai.enabled` 默认为 `false`，如需启用 AI 摘要、关键词功能请在上线前人工置为 `true` 并配置对应表名/路径。
+   - `ai.provider` 支持 `openai`、`qwen`、`claude` 等选项；可在 `ai.providers` 子项中调整不同厂商使用的环境变量命名或接入参数。
 3. 若需自定义标签阈值，请复制示例：
    ```bash
    cp config/labeling.yaml.example config/labeling.yaml

--- a/README.zh.md
+++ b/README.zh.md
@@ -24,7 +24,9 @@ tests/                  # connectors 与 pipelines 的单测
    ```
 2. **配置环境**
    - 复制 `config/secrets.example.env` 为 `.env` 并填写令牌/密码。
+     注：模板中已对 Unified Data、数据库、Keepa、SP-API 以及新增的 Qwen/Claude 模型服务给出申请地址，可按注释提示获取密钥。
    - 根据环境、限流、时间窗口与存储目标调整 `config/settings.yaml`。
+     - `ai.provider` 字段支持 `openai`、`qwen`、`claude` 等选项，可在 `ai.providers` 子项中自定义各厂商所用的环境变量名与连接参数。
 3. **运行测试**
    ```bash
    pytest

--- a/config/secrets.example.env
+++ b/config/secrets.example.env
@@ -1,5 +1,18 @@
+# 统一数据平台 API 基础地址，可在 https://console.your-unified-data.cn 的「API 设置」页面查看
 UNIFIED_API_BASE_URL=https://api.your-unified-data.cn
+# 统一数据平台访问令牌，登录 https://console.your-unified-data.cn 生成
 UNIFIED_API_TOKEN=replace-with-token
+# 数据库密码，登录云数据库控制台（如 https://console.aws.amazon.com/rds/ ）获取
 DB_PASSWORD=replace-with-password
+# Keepa 开发者密钥，订阅 https://keepa.com/#!api 后在仪表盘复制
 KEEPA_API_KEY=optional-keepa-key
+# Amazon Selling Partner API 刷新令牌，登录 https://developer.amazon.com/sp-api/ 获取
 SPAPI_REFRESH_TOKEN=optional-refresh-token
+# Qwen（阿里云百炼 DashScope）API Key，登录 https://dashscope.console.aliyun.com/management/app 获取
+QWEN_API_KEY=optional-qwen-api-key
+# Qwen 兼容 OpenAI 的 API Base，可在 https://dashscope.console.aliyun.com/management/app 查看
+QWEN_API_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+# Claude（Anthropic）API Key，登录 https://console.anthropic.com/account/keys 获取
+CLAUDE_API_KEY=optional-claude-api-key
+# Claude API Base，可在 https://console.anthropic.com/settings 查看
+CLAUDE_API_BASE_URL=https://api.anthropic.com

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -85,6 +85,20 @@ ai:
   comment_summary_table: ""
   keyword_cluster_table: ""
   export_path: ""
+  provider: "openai"
+  providers:
+    openai:
+      label: "OpenAI"
+      api_key_env: "OPENAI_API_KEY"
+      api_base_env: "OPENAI_API_BASE"
+    qwen:
+      label: "Qwen (DashScope)"
+      api_key_env: "QWEN_API_KEY"
+      api_base_env: "QWEN_API_BASE_URL"
+    claude:
+      label: "Claude (Anthropic)"
+      api_key_env: "CLAUDE_API_KEY"
+      api_base_env: "CLAUDE_API_BASE_URL"
 logging:
   level: "INFO"
   json: true


### PR DESCRIPTION
## Summary
- document the acquisition links for each secret in `config/secrets.example.env`
- add Qwen and Claude provider placeholders to the AI configuration and update both READMEs

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4f5393fb4832d88af97a482553ef4